### PR TITLE
Fix GitHub spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Github Profile Summary Cards
+# GitHub Profile Summary Cards
 
 ![Unit Tests](https://github.com/vn7n24fzkq/github-profile-summary-cards/workflows/Unit%20Tests/badge.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/vn7n24fzkq/github-profile-summary-cards/blob/master/LICENSE)
@@ -51,7 +51,7 @@ Then you can use everything in `profile-summary-card-output` folder.
 
 ---
 
-## Github action usage
+## GitHub Actions usage
 
 ### `GITHUB_TOKEN`
 

--- a/docs/README.zh-tw.md
+++ b/docs/README.zh-tw.md
@@ -1,4 +1,4 @@
-# Github Profile Summary Cards
+# GitHub Profile Summary Cards
 
 ![Unit Tests](https://github.com/vn7n24fzkq/github-profile-summary-cards/workflows/Unit%20Tests/badge.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/vn7n24fzkq/github-profile-summary-cards/blob/master/LICENSE)
@@ -43,7 +43,7 @@ Action 已經在這份模板裡設定好了, 你只要按一下 `use this templa
 
 ---
 
-## Github action usage
+## GitHub Actions usage
 
 ### `GITHUB_TOKEN`
 

--- a/tests/github-api/commits-per-language.test.js
+++ b/tests/github-api/commits-per-language.test.js
@@ -61,7 +61,7 @@ const error = {
       type: "NOT_FOUND",
       path: ["user"],
       locations: [],
-      message: "Github api failed",
+      message: "GitHub api failed",
     },
   ],
 };
@@ -85,7 +85,7 @@ describe("commit contributions on github", () => {
   it("should throw error when api failed", async () => {
     mock.onPost("https://api.github.com/graphql").reply(200, error);
     await expect(getCommitLanguage("vn7n24fzkq", 2020)).rejects.toThrow(
-      "Github api failed"
+      "GitHub api failed"
     );
   });
 });

--- a/tests/github-api/contributions-by-year.test.js
+++ b/tests/github-api/contributions-by-year.test.js
@@ -26,7 +26,7 @@ const error = {
       type: "NOT_FOUND",
       path: ["user"],
       locations: [],
-      message: "Github api failed",
+      message: "GitHub api failed",
     },
   ],
 };
@@ -52,7 +52,7 @@ describe("contributions count on github", () => {
   it("should throw error when api failed", async () => {
     mock.onPost("https://api.github.com/graphql").reply(200, error);
     await expect(getContributionByYear("vn7n24fzkq", 2020)).rejects.toThrow(
-      "Github api failed"
+      "GitHub api failed"
     );
   });
 });

--- a/tests/github-api/profile-details.test.js
+++ b/tests/github-api/profile-details.test.js
@@ -62,7 +62,7 @@ const error = {
       type: "NOT_FOUND",
       path: ["user"],
       locations: [],
-      message: "Github api failed",
+      message: "GitHub api failed",
     },
   ],
 };
@@ -106,7 +106,7 @@ describe("github api for profile details", () => {
   it("should throw error when api failed", async () => {
     mock.onPost("https://api.github.com/graphql").reply(200, error);
     await expect(getProfileDetails("vn7n24fzkq")).rejects.toThrow(
-      "Github api failed"
+      "GitHub api failed"
     );
   });
 });

--- a/tests/github-api/repos-per-language.test.js
+++ b/tests/github-api/repos-per-language.test.js
@@ -104,7 +104,7 @@ const error = {
       type: "NOT_FOUND",
       path: ["user"],
       locations: [],
-      message: "Github api failed",
+      message: "GitHub api failed",
     },
   ],
 };
@@ -134,7 +134,7 @@ describe("repos per language on github", () => {
   it("should throw error when api failed", async () => {
     mock.onPost("https://api.github.com/graphql").reply(200, error);
     await expect(getRepoLanguage("vn7n24fzkq")).rejects.toThrow(
-      "Github api failed"
+      "GitHub api failed"
     );
   });
 });


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`.