### PR TITLE
Use primaryLanguage instead of languages in repos per language query

### DIFF
--- a/src/github-api/repos-per-language.js
+++ b/src/github-api/repos-per-language.js
@@ -15,14 +15,9 @@ const fetcher = (token, variables) => {
         user(login: $login) {
           repositories(isFork: false, first: 100, after: $endCursor,ownerAffiliations: OWNER) {
             nodes {
-              languages(first: 10, orderBy: {field: SIZE, direction: DESC}) {
-                edges {
-                  size
-                  node {
-                    color
-                    name
-                  }
-                }
+              primaryLanguage {
+                name
+                color
               }
             }
             pageInfo{
@@ -60,16 +55,15 @@ async function getRepoLanguage(username) {
   }
 
   nodes.forEach((node) => {
-    if (node.languages.edges.length > 0) {
-      let edge = node.languages.edges[0];
-      let langName = edge.node.name;
+    if (node.primaryLanguage) {
+      let langName = node.primaryLanguage.name;
       if (languageMap.has(langName)) {
         let lang = languageMap.get(langName);
         lang.count += 1;
       } else {
         languageMap.set(langName, {
           count: 1,
-          color: edge.node.color ? edge.node.color : "#586e75",
+          color: node.primaryLanguage.color ? node.primaryLanguage.color : "#586e75",
         });
       }
     }

--- a/tests/github-api/repos-per-language.test.js
+++ b/tests/github-api/repos-per-language.test.js
@@ -9,36 +9,15 @@ const firstData = {
       repositories: {
         nodes: [
           {
-            languages: {
-              edges: [
-                {
-                  size: 2072951,
-                  node: {
-                    color: "#b07219",
-                    name: "Java",
-                  },
-                },
-                {
-                  size: 2600,
-                  node: {
-                    color: "#f18e33",
-                    name: "Kotlin",
-                  },
-                },
-              ],
+            primaryLanguage: {
+              color: "#b07219",
+              name: "Java",
             },
           },
           {
-            languages: {
-              edges: [
-                {
-                  size: 10485,
-                  node: {
-                    color: "#dea584",
-                    name: "Rust",
-                  },
-                },
-              ],
+            primaryLanguage: {
+              color: "#dea584",
+              name: "Rust",
             },
           },
         ],
@@ -56,36 +35,15 @@ const lastData = {
       repositories: {
         nodes: [
           {
-            languages: {
-              edges: [
-                {
-                  size: 2072951,
-                  node: {
-                    color: "#b07219",
-                    name: "Java",
-                  },
-                },
-                {
-                  size: 2600,
-                  node: {
-                    color: "#b07219",
-                    name: "Java",
-                  },
-                },
-              ],
+            primaryLanguage: {
+              color: "#b07219",
+              name: "Java",
             },
           },
           {
-            languages: {
-              edges: [
-                {
-                  size: 10485,
-                  node: {
-                    color: "#f18e33",
-                    name: "Kotlin",
-                  },
-                },
-              ],
+            primaryLanguage: {
+              color: "#f18e33",
+              name: "Kotlin",
             },
           },
         ],


### PR DESCRIPTION
The results of repos per language graph seemed odd to me. When I looked into it I noticed that the `languageMap` doesn't include many languages I have projects in. After further inspection I found out that the `languages` array is empty for private repos. I tried using `primaryLanguages` instead of `languages` field and it appears to be working correctly. 

Here are the screenshots before and after the change.

![Screenshot from 2021-03-20 17-32-14](https://user-images.githubusercontent.com/25728391/111877480-e0419100-89a3-11eb-9bd9-00385db94af0.png)
![Screenshot from 2021-03-20 17-34-37](https://user-images.githubusercontent.com/25728391/111877479-df106400-89a3-11eb-81d7-e622faa5069a.png)