### PR TITLE
fix: vercel api timeout

### DIFF
--- a/api/pages/demo.html
+++ b/api/pages/demo.html
@@ -23,6 +23,11 @@
          />
    </head>
    <body>
+      <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
+      <div id="app">
+         <v-app>
+            <v-main>
+               <v-container>
       <a href="https://github.com/vn7n24fzkq/github-profile-summary-cards" class="github-corner" aria-label="View source on GitHub">
          <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
             <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
@@ -30,11 +35,6 @@
             <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
          </svg>
       </a>
-      <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
-      <div id="app">
-         <v-app>
-            <v-main>
-               <v-container>
                   <v-row>
                   <v-col cols="3">
                      <v-card width="800">

--- a/src/cards/most-commit-lauguage-card.js
+++ b/src/cards/most-commit-lauguage-card.js
@@ -1,7 +1,6 @@
 const ThemeMap = require('../const/theme');
 const getCommitLanguage = require('../github-api/commits-per-lauguage');
 const createDonutChartCard = require('../templates/donut-chart-card');
-const getProfileDetails = require('../github-api/profile-details');
 const { writeSVG } = require('../utils/file-writer');
 
 const createCommitsPerLanguageCard = async function (username) {
@@ -32,20 +31,17 @@ const getCommitsLanguageSVG = function (langData, themeName) {
 };
 
 const getCommitsLanguageData = async function (username) {
-    const userDetails = await getProfileDetails(username);
     const langMap = new Map();
-    for (const year of userDetails.contributionYears) {
-        const map = await getCommitLanguage(username, year);
-        for (const [key, value] of map) {
-            if (langMap.has(key)) {
-                const lang = langMap.get(key);
-                lang.count += value.count;
-            } else {
-                langMap.set(key, {
-                    count: value.count,
-                    color: value.color == null ? '#586e75' : value.color,
-                });
-            }
+    const map = await getCommitLanguage(username);
+    for (const [key, value] of map) {
+        if (langMap.has(key)) {
+            const lang = langMap.get(key);
+            lang.count += value.count;
+        } else {
+            langMap.set(key, {
+                count: value.count,
+                color: value.color == null ? '#586e75' : value.color,
+            });
         }
     }
     let langData = [];

--- a/src/cards/productive-time-card.js
+++ b/src/cards/productive-time-card.js
@@ -1,5 +1,4 @@
 const ThemeMap = require('../const/theme');
-const getProfileDetails = require('../github-api/profile-details');
 const getProductiveTime = require('../github-api/productive-time');
 const productiveTimeCard = require('../templates/productive-time-card');
 const { writeSVG } = require('../utils/file-writer');
@@ -28,12 +27,13 @@ const getProductiveTimeSVG = function (productiveTimeData, themeName) {
 };
 
 const getProductiveTimeData = async function (username) {
-    const userId = (await getProfileDetails(username))['id'];
-    const until = new Date(); // get data until now
+    const until = new Date();
+    const since = new Date();
+    since.setFullYear(since.getFullYear() - 1);
     const productiveTime = await getProductiveTime(
         username,
-        userId,
-        until.toISOString()
+        until.toISOString(),
+        since.toISOString()
     );
     // process productiveTime
     const chartData = new Array(24);

--- a/src/cards/profile-details-card.js
+++ b/src/cards/profile-details-card.js
@@ -41,10 +41,10 @@ const getProfileDetailsData = async function (username) {
     profileDetails.username = username;
     let totalContributions = 0;
     if (process.env.VERCEL) {
-        // If running on vercel, we only calculate for last 2 year to avoid hobby timeout limit
+        // If running on vercel, we only calculate for last 1 year to avoid hobby timeout limit
         profileDetails.contributionYears = profileDetails.contributionYears.slice(
             0,
-            2
+            1
         );
         for (const year of profileDetails.contributionYears) {
             totalContributions += (await getContributionByYear(username, year))
@@ -58,15 +58,26 @@ const getProfileDetailsData = async function (username) {
     }
     const numAbbr = new NumAbbr();
     profileDetails.userDetails = [
-        {
-            index: 0,
-            icon: Icons.GITHUB,
-            name: 'Contributions',
-            value: `${numAbbr.abbreviate(
-                totalContributions,
-                2
-            )} Contributions on GitHub`,
-        },
+        // If running on vercel, we only display for last 1 year contributions count
+        !process.env.VERCEL
+            ? {
+                  index: 0,
+                  icon: Icons.GITHUB,
+                  name: 'Contributions',
+                  value: `${numAbbr.abbreviate(
+                      totalContributions,
+                      2
+                  )} Contributions on GitHub`,
+              }
+            : {
+                  index: 0,
+                  icon: Icons.GITHUB,
+                  name: 'Contributions',
+                  value: `${numAbbr.abbreviate(
+                      totalContributions,
+                      2
+                  )} Contributions in ${profileDetails.contributionYears[0]}`,
+              },
         {
             index: 1,
             icon: Icons.REPOS,

--- a/src/cards/profile-details-card.js
+++ b/src/cards/profile-details-card.js
@@ -41,7 +41,7 @@ const getProfileDetailsData = async function (username) {
     profileDetails.username = username;
     let totalContributions = 0;
     if (process.env.VERCEL) {
-        // If running on vercel, we only caculate for last 2 year to avoid hobby timeout limit
+        // If running on vercel, we only calculate for last 2 year to avoid hobby timeout limit
         profileDetails.contributionYears = profileDetails.contributionYears.slice(
             0,
             2

--- a/src/cards/profile-details-card.js
+++ b/src/cards/profile-details-card.js
@@ -40,9 +40,21 @@ const getProfileDetailsData = async function (username) {
     const profileDetails = await getProfileDetails(username);
     profileDetails.username = username;
     let totalContributions = 0;
-    for (const year of profileDetails.contributionYears) {
-        totalContributions += (await getContributionByYear(username, year))
-            .totalContributions;
+    if (process.env.VERCEL) {
+        // If running on vercel, we only caculate for last 2 year to avoid hobby timeout limit
+        profileDetails.contributionYears = profileDetails.contributionYears.slice(
+            0,
+            2
+        );
+        for (const year of profileDetails.contributionYears) {
+            totalContributions += (await getContributionByYear(username, year))
+                .totalContributions;
+        }
+    } else {
+        for (const year of profileDetails.contributionYears) {
+            totalContributions += (await getContributionByYear(username, year))
+                .totalContributions;
+        }
     }
     const numAbbr = new NumAbbr();
     profileDetails.userDetails = [

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -38,10 +38,10 @@ const getStatsData = async function (username) {
     const totalRepositoryContributions =
         profileDetails.totalRepositoryContributions;
     if (process.env.VERCEL) {
-        // If running on vercel, we only calculate for last 2 year to avoid hobby timeout limit
+        // If running on vercel, we only calculate for last 1 year to avoid hobby timeout limit
         profileDetails.contributionYears = profileDetails.contributionYears.slice(
             0,
-            2
+            1
         );
         for (const year of profileDetails.contributionYears) {
             const contributions = await getContributionByYear(username, year);
@@ -62,12 +62,20 @@ const getStatsData = async function (username) {
             name: 'Total Stars:',
             value: `${numAbbr.abbreviate(totalStars, 1)}`,
         },
-        {
-            index: 1,
-            icon: Icons.COMMIT,
-            name: 'Total Commits:',
-            value: `${numAbbr.abbreviate(totalCommitContributions, 1)}`,
-        },
+        // If running on vercel, we only display for last 1 year commits count
+        !process.env.VERCEL
+            ? {
+                  index: 1,
+                  icon: Icons.COMMIT,
+                  name: 'Total Commits:',
+                  value: `${numAbbr.abbreviate(totalCommitContributions, 1)}`,
+              }
+            : {
+                  index: 1,
+                  icon: Icons.COMMIT,
+                  name: `${profileDetails.contributionYears[0]} Commits:`,
+                  value: `${numAbbr.abbreviate(totalCommitContributions, 1)}`,
+              },
         {
             index: 2,
             icon: Icons.PULL_REQUEST,

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -38,7 +38,7 @@ const getStatsData = async function (username) {
     const totalRepositoryContributions =
         profileDetails.totalRepositoryContributions;
     if (process.env.VERCEL) {
-        // If running on vercel, we only caculate for last 2 year to avoid hobby timeout limit
+        // If running on vercel, we only calculate for last 2 year to avoid hobby timeout limit
         profileDetails.contributionYears = profileDetails.contributionYears.slice(
             0,
             2

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -28,21 +28,32 @@ const getStatsSVG = function (StatsData, themeName) {
 };
 
 const getStatsData = async function (username) {
-    const userDetails = await getProfileDetails(username);
-    const totalStars = userDetails.totalStars;
+    const profileDetails = await getProfileDetails(username);
+    const totalStars = profileDetails.totalStars;
     let totalCommitContributions = 0;
-    let totalPullRequestContributions = 0;
-    let totalIssueContributions = 0;
-    let totalRepositoryContributions = 0;
-    for (const year of userDetails.contributionYears) {
-        const contributions = await getContributionByYear(username, year);
-        totalCommitContributions += contributions.totalCommitContributions;
-        totalPullRequestContributions +=
-            contributions.totalPullRequestContributions;
-        totalIssueContributions += contributions.totalIssueContributions;
-        totalRepositoryContributions +=
-            contributions.totalRepositoryContributions;
+    const totalPullRequestContributions =
+        profileDetails.totalPullRequestContributions;
+    const totalIssueContributions = profileDetails.totalIssueContributions;
+
+    const totalRepositoryContributions =
+        profileDetails.totalRepositoryContributions;
+    if (process.env.VERCEL) {
+        // If running on vercel, we only caculate for last 2 year to avoid hobby timeout limit
+        profileDetails.contributionYears = profileDetails.contributionYears.slice(
+            0,
+            2
+        );
+        for (const year of profileDetails.contributionYears) {
+            const contributions = await getContributionByYear(username, year);
+            totalCommitContributions += contributions.totalCommitContributions;
+        }
+    } else {
+        for (const year of profileDetails.contributionYears) {
+            const contributions = await getContributionByYear(username, year);
+            totalCommitContributions += contributions.totalCommitContributions;
+        }
     }
+
     const numAbbr = new NumAbbr();
     const statsData = [
         {

--- a/src/github-api/commits-per-lauguage.js
+++ b/src/github-api/commits-per-lauguage.js
@@ -1,6 +1,6 @@
 const request = require('../utils/request.js');
 
-const fetcher = (token, variables, year) => {
+const fetcher = (token, variables) => {
     return request(
         {
             Authorization: `bearer ${token}`,
@@ -9,7 +9,7 @@ const fetcher = (token, variables, year) => {
             query: `
       query CommitLanguages($login: String!) {
         user(login: $login) {
-          contributionsCollection(from: "${year}-01-01T00:00:00Z", to: "${year}-12-31T23:59:59Z") {
+          contributionsCollection {
             commitContributionsByRepository(maxRepositories: 100) {
               repository {
                 primaryLanguage {
@@ -31,16 +31,12 @@ const fetcher = (token, variables, year) => {
 };
 
 // repos per language
-async function getCommitLanguage(username, year) {
+async function getCommitLanguage(username) {
     const languageMap = new Map();
 
-    const res = await fetcher(
-        process.env.GITHUB_TOKEN,
-        {
-            login: username,
-        },
-        year
-    );
+    const res = await fetcher(process.env.GITHUB_TOKEN, {
+        login: username,
+    });
 
     if (res.data.errors) {
         throw Error(res.data.errors[0].message || 'GetCommitLanguage failed');

--- a/src/github-api/contributions-by-year.js
+++ b/src/github-api/contributions-by-year.js
@@ -9,18 +9,18 @@ const fetcher = (token, variables, year) => {
             query: `
       query ContributionsByYear($login: String!) {
         user(login: $login) {
-            contributionsCollection(from: "${year}-01-01T00:00:00Z", to: "${year}-12-31T23:59:59Z") {
-                totalPullRequestReviewContributions
-                totalIssueContributions
-                totalCommitContributions
-                totalPullRequestContributions
-                totalRepositoryContributions
-                contributionCalendar {
-                    totalContributions
+            ${
+                year
+                    ? `contributionsCollection(from: "${year}-01-01T00:00:00Z", to: "${year}-12-31T23:59:59Z") {`
+                    : 'contributionsCollection {'
+            }
+                    totalCommitContributions
+                    contributionCalendar {
+                        totalContributions
+                    }
                 }
             }
         }
-      }
       `,
             variables,
         }
@@ -29,12 +29,8 @@ const fetcher = (token, variables, year) => {
 
 async function getContributionByYear(username, year) {
     const result = {
-        totalContributions: 0,
-        totalPullRequestReviewContributions: 0,
-        totalIssueContributions: 0,
         totalCommitContributions: 0,
-        totalPullRequestContributions: 0,
-        totalRepositoryContributions: 0,
+        totalContributions: 0,
     };
 
     const res = await fetcher(
@@ -53,19 +49,10 @@ async function getContributionByYear(username, year) {
 
     const user = res.data.data.user;
 
-    result.totalRepositoryContributions =
-        user.contributionsCollection.totalRepositoryContributions;
-    result.totalPullRequestContributions =
-        user.contributionsCollection.totalPullRequestContributions;
-    result.totalPullRequestReviewContributions =
-        user.contributionsCollection.totalPullRequestReviewContributions;
-    result.totalIssueContributions =
-        user.contributionsCollection.totalIssueContributions;
     result.totalCommitContributions =
         user.contributionsCollection.totalCommitContributions;
     result.totalContributions =
         user.contributionsCollection.contributionCalendar.totalContributions;
-
     return result;
 }
 

--- a/src/github-api/profile-details.js
+++ b/src/github-api/profile-details.js
@@ -38,6 +38,15 @@ const fetcher = (token, variables) => {
                 }
                 contributionYears
             }
+            repositoriesContributedTo(first: 1,includeUserRepositories:true, privacy:PUBLIC, contributionTypes: [COMMIT, ISSUE, PULL_REQUEST, REPOSITORY]) {
+                totalCount
+            }
+            pullRequests(first: 1) {
+                totalCount
+            }
+            issues(first: 1) {
+                totalCount
+            }
         }
       }
 
@@ -59,6 +68,9 @@ async function getProfileDetails(username) {
         location: null,
         totalPublicRepos: 0,
         totalStars: 0,
+        totalIssueContributions: 0,
+        totalPullRequestContributions: 0,
+        totalRepositoryContributions: 0,
         contributions: [],
         contributionYears: [],
     };
@@ -82,6 +94,10 @@ async function getProfileDetails(username) {
         return stars + curr.stargazers.totalCount;
     }, 0);
     result.websiteUrl = user.websiteUrl;
+    result.totalIssueContributions = user.issues.totalCount;
+    result.totalPullRequestContributions = user.pullRequests.totalCount;
+    result.totalRepositoryContributions =
+        user.repositoriesContributedTo.totalCount;
     result.company = user.company;
     result.location = user.location;
     result.twitterUsername = user.twitterUsername;

--- a/tests/github-api/contributions-by-year.test.js
+++ b/tests/github-api/contributions-by-year.test.js
@@ -7,11 +7,7 @@ const data = {
     data: {
         user: {
             contributionsCollection: {
-                totalIssueContributions: 20,
                 totalCommitContributions: 30,
-                totalRepositoryContributions: 40,
-                totalPullRequestContributions: 50,
-                totalPullRequestReviewContributions: 60,
                 contributionCalendar: {
                     totalContributions: 10,
                 },
@@ -43,11 +39,7 @@ describe('contributions count on github', () => {
             2020
         );
         expect(totalContributions).toStrictEqual({
-            totalPullRequestReviewContributions: 60,
-            totalPullRequestContributions: 50,
-            totalRepositoryContributions: 40,
             totalCommitContributions: 30,
-            totalIssueContributions: 20,
             totalContributions: 10,
         });
     });

--- a/tests/github-api/profile-details.test.js
+++ b/tests/github-api/profile-details.test.js
@@ -21,12 +21,10 @@ const data = {
                     { stargazers: { totalCount: 20 } },
                 ],
             },
+            issues: { totalCount: 10 },
+            repositoriesContributedTo: { totalCount: 30 },
+            pullRequests: { totalCount: 40 },
             contributionsCollection: {
-                totalIssueContributions: 10,
-                totalCommitContributions: 20,
-                totalRepositoryContributions: 30,
-                totalPullRequestContributions: 40,
-                totalPullRequestReviewContributions: 50,
                 contributionYears: [2019, 2020],
                 contributionCalendar: {
                     weeks: [
@@ -88,6 +86,9 @@ describe('github api for profile details', () => {
             contributionYears: [2019, 2020],
             totalPublicRepos: 30,
             totalStars: 130,
+            totalIssueContributions: 10,
+            totalPullRequestContributions: 40,
+            totalRepositoryContributions: 30,
             contributions: [
                 {
                     date: new Date('2019-09-06T00:00:00.000+00:00'),


### PR DESCRIPTION
* We modify some GraphQL API to decrease response time.
* We rewrite the logic for `Top Language By Commit` Card, now we only calculate commits in the last year so that can be more dynamically.
* If you using URL usage, some summary only contain in two year, this behavior can avoid vercel get 502 error in hobby plan account.