### PR TITLE
Update GitHub action/checkout@v2 -> v3

### DIFF
--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         api_key: ${{ secrets.foresight_api_key }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2
       with:
@@ -53,7 +53,7 @@ jobs:
         node-version: [16.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2
       with:

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ jobs:
     name: generate-github-profile-summary-cards
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: vn7n24fzkq/github-profile-summary-cards@release
         env: # default use ${{ secrets.SUMMARY_GITHUB_TOKEN }}, you should replace with your personal access token
           GITHUB_TOKEN: ${{ secrets.SUMMARY_GITHUB_TOKEN }}

--- a/docs/README.zh-tw.md
+++ b/docs/README.zh-tw.md
@@ -86,7 +86,7 @@ jobs:
     name: generate-github-profile-summary-cards
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: vn7n24fzkq/github-profile-summary-cards@release
         env: # default use ${{ secrets.SUMMARY_GITHUB_TOKEN }}, you should replace with your personal access token
           GITHUB_TOKEN: ${{ secrets.SUMMARY_GITHUB_TOKEN }}


### PR DESCRIPTION
For removing GitHub Actions annotation `action/checkout@v2`

- this repository GitHub Action
  - example https://github.com/vn7n24fzkq/github-profile-summary-cards/actions/runs/3508607285
- readme usage for users

![image](https://user-images.githubusercontent.com/38120991/208219040-ae7f29e8-55b7-4845-a6a5-8ee93d7b2a23.png)
