### PR TITLE
feat(action): Bump GitHub setup-node to v3

### DIFF
--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -25,7 +25,7 @@ jobs:
 
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'


### PR DESCRIPTION
Fix GitHub Actions annotation below 🔧

```
Lint (16.x)
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/setup-node@v2
```