### PR TITLE
chore: Add test reporter for CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "format-check": "prettier --check '**/*.ts'",
         "lint": "eslint src/**/*.ts",
         "package": "ncc build --source-map --license licenses.txt",
-        "test": "jest --passWithNoTests --reporters=jest-junit --coverage",
+        "test": "jest --passWithNoTests --reporters=default --reporters=jest-junit --coverage",
         "run": "node -r dotenv/config lib/app.js",
         "all": "npm run build && npm run format && npm run lint && npm run package && npm test"
     },


### PR DESCRIPTION
I want to add test reporter for CLI :)

- ref: https://jestjs.io/docs/cli#--reporters
  - `Run tests with specified reporters. Reporter options are not available via CLI.`
- ref: https://jestjs.io/docs/configuration#reporters-arraymodulename--modulename-options

## before

```sh
➜ npm run test

> github-profile-summary-cards@0.5.2 test
> jest --passWithNoTests --reporters=jest-junit --coverage

(node:45571) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
-------------------------------|---------|----------|---------|---------|-------------------
File                           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-------------------------------|---------|----------|---------|---------|-------------------
All files                      |   19.95 |    15.12 |   18.69 |   20.43 |
 api                           |       0 |      100 |       0 |       0 |
  theme.ts                     |       0 |      100 |       0 |       0 | 1-6
 api/cards                     |       0 |        0 |       0 |       0 |
  most-commit-language.ts      |       0 |        0 |       0 |       0 | 1-44
  productive-time.ts           |       0 |        0 |       0 |       0 | 1-37
  profile-details.ts           |       0 |        0 |       0 |       0 | 1-33
  repos-per-language.ts        |       0 |        0 |       0 |       0 | 1-43
  stats.ts                     |       0 |        0 |       0 |       0 | 1-33
 api/utils                     |       0 |        0 |       0 |       0 |
  error-card.ts                |       0 |      100 |       0 |       0 | 1-13
  github-token-updater.ts      |       0 |        0 |       0 |       0 | 1-6
 src                           |       0 |        0 |       0 |       0 |
  app.ts                       |       0 |        0 |       0 |       0 | 1-145
 src/cards                     |       0 |        0 |       0 |       0 |
  most-commit-lauguage-card.ts |       0 |        0 |       0 |       0 | 1-70
  productive-time-card.ts      |       0 |        0 |       0 |       0 | 1-58
  profile-details-card.ts      |       0 |        0 |       0 |       0 | 1-131
  repos-per-language-card.ts   |       0 |        0 |       0 |       0 | 1-46
  stats-card.ts                |       0 |        0 |       0 |       0 | 1-97
 src/const                     |      96 |      100 |     100 |      96 |
  icon.ts                      |       0 |      100 |     100 |       0 | 2
  theme.ts                     |     100 |      100 |     100 |     100 |
 src/github-api                |   83.21 |    54.83 |   68.96 |   83.21 |
  commits-per-language.ts      |   96.55 |       75 |   85.71 |   96.55 | 29
  contributions-by-year.ts     |     100 |       60 |     100 |     100 | 24,51
  productive-time.ts           |       0 |        0 |       0 |       0 | 1-108
  profile-details.ts           |     100 |    66.66 |     100 |     100 | 98
  repos-per-language.ts        |   97.05 |       75 |   85.71 |   97.05 | 29
 src/templates                 |       0 |        0 |       0 |       0 |
  card.ts                      |       0 |        0 |       0 |       0 | 2-65
  donut-chart-card.ts          |       0 |      100 |       0 |       0 | 1-76
  productive-time-card.ts      |       0 |        0 |       0 |       0 | 1-92
  profile-details-card.ts      |       0 |        0 |       0 |       0 | 1-154
  stats-card.ts                |       0 |      100 |       0 |       0 | 1-60
 src/utils                     |    32.2 |       10 |   22.22 |    30.9 |
  file-writer.ts               |   29.54 |       20 |   16.66 |   26.82 | 21-25,29-93
  request.ts                   |   66.66 |        0 |      50 |   66.66 | 20-22
  translator.ts                |       0 |        0 |       0 |       0 | 1-272
-------------------------------|---------|----------|---------|---------|-------------------
```

## after

```sh
➜ npm run test

> github-profile-summary-cards@0.5.2 test
> jest --passWithNoTests --reporters=default --reporters=jest-junit --coverage

(node:67940) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
 PASS  tests/utils/file-writer.test.ts
  Test output function
    ✓ test write svg can work (2 ms)

 PASS  tests/github-api/repos-per-language.test.ts
  repos per language on github
    ✓ should get correct data (4 ms)
    ✓ should throw error when api failed (15 ms)

 PASS  tests/const/theme.test.ts
  Validate all theme
    ✓ theme colors are match the color regex (6 ms)

 PASS  tests/github-api/profile-details.test.ts
  github api for profile details
    ✓ should get correct profile data (2 ms)
    ✓ should throw error when api failed (4 ms)

 PASS  tests/github-api/commits-per-language.test.ts
  commit contributions on github
    ✓ should get correct commit contributions (2 ms)
    ✓ should throw error when api failed (3 ms)

 PASS  tests/github-api/contributions-by-year.test.ts
  contributions count on github
    ✓ should get correct contributions (2 ms)
    ✓ should throw error when api failed (2 ms)

-------------------------------|---------|----------|---------|---------|-------------------
File                           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-------------------------------|---------|----------|---------|---------|-------------------
All files                      |   19.95 |    15.12 |   18.69 |   20.43 |
 api                           |       0 |      100 |       0 |       0 |
  theme.ts                     |       0 |      100 |       0 |       0 | 1-6
 api/cards                     |       0 |        0 |       0 |       0 |
  most-commit-language.ts      |       0 |        0 |       0 |       0 | 1-44
  productive-time.ts           |       0 |        0 |       0 |       0 | 1-37
  profile-details.ts           |       0 |        0 |       0 |       0 | 1-33
  repos-per-language.ts        |       0 |        0 |       0 |       0 | 1-43
  stats.ts                     |       0 |        0 |       0 |       0 | 1-33
 api/utils                     |       0 |        0 |       0 |       0 |
  error-card.ts                |       0 |      100 |       0 |       0 | 1-13
  github-token-updater.ts      |       0 |        0 |       0 |       0 | 1-6
 src                           |       0 |        0 |       0 |       0 |
  app.ts                       |       0 |        0 |       0 |       0 | 1-145
 src/cards                     |       0 |        0 |       0 |       0 |
  most-commit-lauguage-card.ts |       0 |        0 |       0 |       0 | 1-70
  productive-time-card.ts      |       0 |        0 |       0 |       0 | 1-58
  profile-details-card.ts      |       0 |        0 |       0 |       0 | 1-131
  repos-per-language-card.ts   |       0 |        0 |       0 |       0 | 1-46
  stats-card.ts                |       0 |        0 |       0 |       0 | 1-97
 src/const                     |      96 |      100 |     100 |      96 |
  icon.ts                      |       0 |      100 |     100 |       0 | 2
  theme.ts                     |     100 |      100 |     100 |     100 |
 src/github-api                |   83.21 |    54.83 |   68.96 |   83.21 |
  commits-per-language.ts      |   96.55 |       75 |   85.71 |   96.55 | 29
  contributions-by-year.ts     |     100 |       60 |     100 |     100 | 24,51
  productive-time.ts           |       0 |        0 |       0 |       0 | 1-108
  profile-details.ts           |     100 |    66.66 |     100 |     100 | 98
  repos-per-language.ts        |   97.05 |       75 |   85.71 |   97.05 | 29
 src/templates                 |       0 |        0 |       0 |       0 |
  card.ts                      |       0 |        0 |       0 |       0 | 2-65
  donut-chart-card.ts          |       0 |      100 |       0 |       0 | 1-76
  productive-time-card.ts      |       0 |        0 |       0 |       0 | 1-92
  profile-details-card.ts      |       0 |        0 |       0 |       0 | 1-154
  stats-card.ts                |       0 |      100 |       0 |       0 | 1-60
 src/utils                     |    32.2 |       10 |   22.22 |    30.9 |
  file-writer.ts               |   29.54 |       20 |   16.66 |   26.82 | 21-25,29-93
  request.ts                   |   66.66 |        0 |      50 |   66.66 | 20-22
  translator.ts                |       0 |        0 |       0 |       0 | 1-272
-------------------------------|---------|----------|---------|---------|-------------------
Test Suites: 6 passed, 6 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        4.646 s
Ran all test suites.
```