### PR TITLE
fix: Donwgrade d3 to v6 for v7 breaking changes 🔽

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@actions/github": "^5.0.0",
                 "axios": "^0.21.3",
                 "childprocess": "^2.0.2",
-                "d3": "^7.6.1",
+                "d3": "^6.7.0",
                 "dotenv": "^8.2.0",
                 "jest-junit": "^14.0.0",
                 "js-abbreviation-number": "^1.4.0",
@@ -22,7 +22,7 @@
                 "retry-axios": "^2.6.0"
             },
             "devDependencies": {
-                "@types/d3": "^7.1.0",
+                "@types/d3": "^6.7.0",
                 "@types/jest": "^27.0.2",
                 "@types/jsdom": "^16.2.13",
                 "@types/node": "^16.11.6",
@@ -1241,262 +1241,262 @@
             "dev": true
         },
         "node_modules/@types/d3": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.1.0.tgz",
-            "integrity": "sha512-gYWvgeGjEl+zmF8c+U1RNIKqe7sfQwIXeLXO5Os72TjDjCEtgpvGBvZ8dXlAuSS1m6B90Y1Uo6Bm36OGR/OtCA==",
+            "version": "6.7.5",
+            "resolved": "https://registry.npmjs.org/@types/d3/-/d3-6.7.5.tgz",
+            "integrity": "sha512-TUZ6zuT/KIvbHSv81kwAiO5gG5aTuoiLGnWR/KxHJ15Idy/xmGUXaaF5zMG+UMIsndcGlSHTmrvwRgdvZlNKaA==",
             "dev": true,
             "dependencies": {
-                "@types/d3-array": "*",
-                "@types/d3-axis": "*",
-                "@types/d3-brush": "*",
-                "@types/d3-chord": "*",
-                "@types/d3-color": "*",
-                "@types/d3-contour": "*",
-                "@types/d3-delaunay": "*",
-                "@types/d3-dispatch": "*",
-                "@types/d3-drag": "*",
-                "@types/d3-dsv": "*",
-                "@types/d3-ease": "*",
-                "@types/d3-fetch": "*",
-                "@types/d3-force": "*",
-                "@types/d3-format": "*",
-                "@types/d3-geo": "*",
-                "@types/d3-hierarchy": "*",
-                "@types/d3-interpolate": "*",
-                "@types/d3-path": "*",
-                "@types/d3-polygon": "*",
-                "@types/d3-quadtree": "*",
-                "@types/d3-random": "*",
-                "@types/d3-scale": "*",
-                "@types/d3-scale-chromatic": "*",
-                "@types/d3-selection": "*",
-                "@types/d3-shape": "*",
-                "@types/d3-time": "*",
-                "@types/d3-time-format": "*",
-                "@types/d3-timer": "*",
-                "@types/d3-transition": "*",
-                "@types/d3-zoom": "*"
+                "@types/d3-array": "^2",
+                "@types/d3-axis": "^2",
+                "@types/d3-brush": "^2",
+                "@types/d3-chord": "^2",
+                "@types/d3-color": "^2",
+                "@types/d3-contour": "^2",
+                "@types/d3-delaunay": "^5",
+                "@types/d3-dispatch": "^2",
+                "@types/d3-drag": "^2",
+                "@types/d3-dsv": "^2",
+                "@types/d3-ease": "^2",
+                "@types/d3-fetch": "^2",
+                "@types/d3-force": "^2",
+                "@types/d3-format": "^2",
+                "@types/d3-geo": "^2",
+                "@types/d3-hierarchy": "^2",
+                "@types/d3-interpolate": "^2",
+                "@types/d3-path": "^2",
+                "@types/d3-polygon": "^2",
+                "@types/d3-quadtree": "^2",
+                "@types/d3-random": "^2",
+                "@types/d3-scale": "^3",
+                "@types/d3-scale-chromatic": "^2",
+                "@types/d3-selection": "^2",
+                "@types/d3-shape": "^2",
+                "@types/d3-time": "^2",
+                "@types/d3-time-format": "^3",
+                "@types/d3-timer": "^2",
+                "@types/d3-transition": "^2",
+                "@types/d3-zoom": "^2"
             }
         },
         "node_modules/@types/d3-array": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.2.tgz",
-            "integrity": "sha512-5mjGjz6XOXKOCdTajXTZ/pMsg236RdiwKPrRPWAEf/2S/+PzwY+LLYShUpeysWaMvsdS7LArh6GdUefoxpchsQ==",
+            "version": "2.12.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-2.12.3.tgz",
+            "integrity": "sha512-hN879HLPTVqZV3FQEXy7ptt083UXwguNbnxdTGzVW4y4KjX5uyNKljrQixZcSJfLyFirbpUokxpXtvR+N5+KIg==",
             "dev": true
         },
         "node_modules/@types/d3-axis": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.1.tgz",
-            "integrity": "sha512-zji/iIbdd49g9WN0aIsGcwcTBUkgLsCSwB+uH+LPVDAiKWENMtI3cJEWt+7/YYwelMoZmbBfzA3qCdrZ2XFNnw==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-2.1.3.tgz",
+            "integrity": "sha512-QjXjwZ0xzyrW2ndkmkb09ErgWDEYtbLBKGui73QLMFm3woqWpxptfD5Y7vqQdybMcu7WEbjZ5q+w2w5+uh2IjA==",
             "dev": true,
             "dependencies": {
-                "@types/d3-selection": "*"
+                "@types/d3-selection": "^2"
             }
         },
         "node_modules/@types/d3-brush": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.1.tgz",
-            "integrity": "sha512-B532DozsiTuQMHu2YChdZU0qsFJSio3Q6jmBYGYNp3gMDzBmuFFgPt9qKA4VYuLZMp4qc6eX7IUFUEsvHiXZAw==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-2.1.2.tgz",
+            "integrity": "sha512-DnZmjdK1ycX1CMiW9r5E3xSf1tL+bp3yob1ON8bf0xB0/odfmGXeYOTafU+2SmU1F0/dvcqaO4SMjw62onOu6A==",
             "dev": true,
             "dependencies": {
-                "@types/d3-selection": "*"
+                "@types/d3-selection": "^2"
             }
         },
         "node_modules/@types/d3-chord": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.1.tgz",
-            "integrity": "sha512-eQfcxIHrg7V++W8Qxn6QkqBNBokyhdWSAS73AbkbMzvLQmVVBviknoz2SRS/ZJdIOmhcmmdCRE/NFOm28Z1AMw==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-2.0.3.tgz",
+            "integrity": "sha512-koIqSNQLPRQPXt7c55hgRF6Lr9Ps72r1+Biv55jdYR+SHJ463MsB2lp4ktzttFNmrQw/9yWthf/OmSUj5dNXKw==",
             "dev": true
         },
         "node_modules/@types/d3-color": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.0.2.tgz",
-            "integrity": "sha512-WVx6zBiz4sWlboCy7TCgjeyHpNjMsoF36yaagny1uXfbadc9f+5BeBf7U+lRmQqY3EHbGQpP8UdW8AC+cywSwQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-2.0.3.tgz",
+            "integrity": "sha512-+0EtEjBfKEDtH9Rk3u3kLOUXM5F+iZK+WvASPb0MhIZl8J8NUvGeZRwKCXl+P3HkYx5TdU4YtcibpqHkSR9n7w==",
             "dev": true
         },
         "node_modules/@types/d3-contour": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.1.tgz",
-            "integrity": "sha512-C3zfBrhHZvrpAAK3YXqLWVAGo87A4SvJ83Q/zVJ8rFWJdKejUnDYaWZPkA8K84kb2vDA/g90LTQAz7etXcgoQQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-2.0.4.tgz",
+            "integrity": "sha512-WMac1xV/mXAgkgr5dUvzsBV5OrgNZDBDpJk9s3v2SadTqGgDRirKABb2Ek2H1pFlYVH4Oly9XJGnuzxKDduqWA==",
             "dev": true,
             "dependencies": {
-                "@types/d3-array": "*",
+                "@types/d3-array": "^2",
                 "@types/geojson": "*"
             }
         },
         "node_modules/@types/d3-delaunay": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.0.tgz",
-            "integrity": "sha512-iGm7ZaGLq11RK3e69VeMM6Oqj2SjKUB9Qhcyd1zIcqn2uE8w9GFB445yCY46NOQO3ByaNyktX1DK+Etz7ZaX+w==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-5.3.1.tgz",
+            "integrity": "sha512-F6itHi2DxdatHil1rJ2yEFUNhejj8+0Acd55LZ6Ggwbdoks0+DxVY2cawNj16sjCBiWvubVlh6eBMVsYRNGLew==",
             "dev": true
         },
         "node_modules/@types/d3-dispatch": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
-            "integrity": "sha512-NhxMn3bAkqhjoxabVJWKryhnZXXYYVQxaBnbANu0O94+O/nX9qSjrA1P1jbAQJxJf+VC72TxDX/YJcKue5bRqw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-2.0.1.tgz",
+            "integrity": "sha512-eT2K8uG3rXkmRiCpPn0rNrekuSLdBfV83vbTvfZliA5K7dbeaqWS/CBHtJ9SQoF8aDTsWSY4A0RU67U/HcKdJQ==",
             "dev": true
         },
         "node_modules/@types/d3-drag": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.1.tgz",
-            "integrity": "sha512-o1Va7bLwwk6h03+nSM8dpaGEYnoIG19P0lKqlic8Un36ymh9NSkNFX1yiXMKNMx8rJ0Kfnn2eovuFaL6Jvj0zA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-2.0.2.tgz",
+            "integrity": "sha512-m9USoFaTgVw2mmE7vLjWTApT9dMxMlql/dl3Gj503x+1a2n6K455iDWydqy2dfCpkUBCoF82yRGDgcSk9FUEyQ==",
             "dev": true,
             "dependencies": {
-                "@types/d3-selection": "*"
+                "@types/d3-selection": "^2"
             }
         },
         "node_modules/@types/d3-dsv": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.0.tgz",
-            "integrity": "sha512-o0/7RlMl9p5n6FQDptuJVMxDf/7EDEv2SYEO/CwdG2tr1hTfUVi0Iavkk2ax+VpaQ/1jVhpnj5rq1nj8vwhn2A==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-2.0.3.tgz",
+            "integrity": "sha512-15sp4Z+ZVWuZuV0QEDu4cu/0C5vlD+JYXaUMDs8JTWpTJjcrAtjyR1vVwEfbgmU5kLNOOMRTlDCYyWWFx7eh/w==",
             "dev": true
         },
         "node_modules/@types/d3-ease": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.0.tgz",
-            "integrity": "sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-2.0.2.tgz",
+            "integrity": "sha512-29Y73Tg6o6aL+3/S/kEun84m5BO4bjRNau6pMWv9N9rZHcJv/O/07mW6EjqxrePZZS64fj0wiB5LMHr4Jzf3eQ==",
             "dev": true
         },
         "node_modules/@types/d3-fetch": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.1.tgz",
-            "integrity": "sha512-toZJNOwrOIqz7Oh6Q7l2zkaNfXkfR7mFSJvGvlD/Ciq/+SQ39d5gynHJZ/0fjt83ec3WL7+u3ssqIijQtBISsw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-2.0.2.tgz",
+            "integrity": "sha512-sllsCSWrNdSvzOJWN5RnxkmtvW9pCttONGajSxHX9FUQ9kOkGE391xlz6VDBdZxLnpwjp3I+mipbwsaCjq4m5A==",
             "dev": true,
             "dependencies": {
-                "@types/d3-dsv": "*"
+                "@types/d3-dsv": "^2"
             }
         },
         "node_modules/@types/d3-force": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.3.tgz",
-            "integrity": "sha512-z8GteGVfkWJMKsx6hwC3SiTSLspL98VNpmvLpEFJQpZPq6xpA1I8HNBDNSpukfK0Vb0l64zGFhzunLgEAcBWSA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-2.1.4.tgz",
+            "integrity": "sha512-1XVRc2QbeUSL1FRVE53Irdz7jY+drTwESHIMVirCwkAAMB/yVC8ezAfx/1Alq0t0uOnphoyhRle1ht5CuPgSJQ==",
             "dev": true
         },
         "node_modules/@types/d3-format": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz",
-            "integrity": "sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-2.0.2.tgz",
+            "integrity": "sha512-OhQPuTeeMhD9A0Ksqo4q1S9Z1Q57O/t4tTPBxBQxRB4IERnxeoEYLPe72fA/GYpPSUrfKZVOgLHidkxwbzLdJA==",
             "dev": true
         },
         "node_modules/@types/d3-geo": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.0.2.tgz",
-            "integrity": "sha512-DbqK7MLYA8LpyHQfv6Klz0426bQEf7bRTvhMy44sNGVyZoWn//B0c+Qbeg8Osi2Obdc9BLLXYAKpyWege2/7LQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-2.0.4.tgz",
+            "integrity": "sha512-kP0LcPVN6P/42hmFt0kZm93YTscfawZo6tioL9y0Ya2l5rxaGoYrIG4zee+yJoK9cLTOc8E8S5ExqTEYVwjIkw==",
             "dev": true,
             "dependencies": {
                 "@types/geojson": "*"
             }
         },
         "node_modules/@types/d3-hierarchy": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.0.2.tgz",
-            "integrity": "sha512-+krnrWOZ+aQB6v+E+jEkmkAx9HvsNAD+1LCD0vlBY3t+HwjKnsBFbpVLx6WWzDzCIuiTWdAxXMEnGnVXpB09qQ==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-2.0.2.tgz",
+            "integrity": "sha512-6PlBRwbjUPPt0ZFq/HTUyOAdOF3p73EUYots74lHMUyAVtdFSOS/hAeNXtEIM9i7qRDntuIblXxHGUMb9MuNRA==",
             "dev": true
         },
         "node_modules/@types/d3-interpolate": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-            "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-2.0.2.tgz",
+            "integrity": "sha512-lElyqlUfIPyWG/cD475vl6msPL4aMU7eJvx1//Q177L8mdXoVPFl1djIESF2FKnc0NyaHvQlJpWwKJYwAhUoCw==",
             "dev": true,
             "dependencies": {
-                "@types/d3-color": "*"
+                "@types/d3-color": "^2"
             }
         },
         "node_modules/@types/d3-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.0.tgz",
-            "integrity": "sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.2.tgz",
+            "integrity": "sha512-3YHpvDw9LzONaJzejXLOwZ3LqwwkoXb9LI2YN7Hbd6pkGo5nIlJ09ul4bQhBN4hQZJKmUpX8HkVqbzgUKY48cg==",
             "dev": true
         },
         "node_modules/@types/d3-polygon": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.0.tgz",
-            "integrity": "sha512-D49z4DyzTKXM0sGKVqiTDTYr+DHg/uxsiWDAkNrwXYuiZVd9o9wXZIo+YsHkifOiyBkmSWlEngHCQme54/hnHw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-2.0.1.tgz",
+            "integrity": "sha512-X3XTIwBxlzRIWe4yaD1KsmcfItjSPLTGL04QDyP08jyHDVsnz3+NZJMwtD4vCaTAVpGSjbqS+jrBo8cO2V/xMA==",
             "dev": true
         },
         "node_modules/@types/d3-quadtree": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.2.tgz",
-            "integrity": "sha512-QNcK8Jguvc8lU+4OfeNx+qnVy7c0VrDJ+CCVFS9srBo2GL9Y18CnIxBdTF3v38flrGy5s1YggcoAiu6s4fLQIw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-2.0.2.tgz",
+            "integrity": "sha512-KgWL4jlz8QJJZX01E4HKXJ9FLU94RTuObsAYqsPp8YOAcYDmEgJIQJ+ojZcnKUAnrUb78ik8JBKWas5XZPqJnQ==",
             "dev": true
         },
         "node_modules/@types/d3-random": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.1.tgz",
-            "integrity": "sha512-IIE6YTekGczpLYo/HehAy3JGF1ty7+usI97LqraNa8IiDur+L44d0VOjAvFQWJVdZOJHukUJw+ZdZBlgeUsHOQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-2.2.1.tgz",
+            "integrity": "sha512-5vvxn6//poNeOxt1ZwC7QU//dG9QqABjy1T7fP/xmFHY95GnaOw3yABf29hiu5SR1Oo34XcpyHFbzod+vemQjA==",
             "dev": true
         },
         "node_modules/@types/d3-scale": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.2.tgz",
-            "integrity": "sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.3.2.tgz",
+            "integrity": "sha512-gGqr7x1ost9px3FvIfUMi5XA/F/yAf4UkUDtdQhpH92XCT0Oa7zkkRzY61gPVJq+DxpHn/btouw5ohWkbBsCzQ==",
             "dev": true,
             "dependencies": {
-                "@types/d3-time": "*"
+                "@types/d3-time": "^2"
             }
         },
         "node_modules/@types/d3-scale-chromatic": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
-            "integrity": "sha512-dsoJGEIShosKVRBZB0Vo3C8nqSDqVGujJU6tPznsBJxNJNwMF8utmS83nvCBKQYPpjCzaaHcrf66iTRpZosLPw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-2.0.1.tgz",
+            "integrity": "sha512-3EuZlbPu+pvclZcb1DhlymTWT2W+lYsRKBjvkH2ojDbCWDYavifqu1vYX9WGzlPgCgcS4Alhk1+zapXbGEGylQ==",
             "dev": true
         },
         "node_modules/@types/d3-selection": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.1.tgz",
-            "integrity": "sha512-aJ1d1SCUtERHH65bB8NNoLpUOI3z8kVcfg2BGm4rMMUwuZF4x6qnIEKjT60Vt0o7gP/a/xkRVs4D9CpDifbyRA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-2.0.1.tgz",
+            "integrity": "sha512-3mhtPnGE+c71rl/T5HMy+ykg7migAZ4T6gzU0HxpgBFKcasBrSnwRbYV1/UZR6o5fkpySxhWxAhd7yhjj8jL7g==",
             "dev": true
         },
         "node_modules/@types/d3-shape": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.0.2.tgz",
-            "integrity": "sha512-5+ButCmIfNX8id5seZ7jKj3igdcxx+S9IDBiT35fQGTLZUfkFgTv+oBH34xgeoWDKpWcMITSzBILWQtBoN5Piw==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.1.3.tgz",
+            "integrity": "sha512-HAhCel3wP93kh4/rq+7atLdybcESZ5bRHDEZUojClyZWsRuEMo3A52NGYJSh48SxfxEU6RZIVbZL2YFZ2OAlzQ==",
             "dev": true,
             "dependencies": {
-                "@types/d3-path": "*"
+                "@types/d3-path": "^2"
             }
         },
         "node_modules/@types/d3-time": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
-            "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.1.1.tgz",
+            "integrity": "sha512-9MVYlmIgmRR31C5b4FVSWtuMmBHh2mOWQYfl7XAYOa8dsnb7iEmUmRSWSFgXFtkjxO65d7hTUHQC+RhR/9IWFg==",
             "dev": true
         },
         "node_modules/@types/d3-time-format": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.0.tgz",
-            "integrity": "sha512-yjfBUe6DJBsDin2BMIulhSHmr5qNR5Pxs17+oW4DoVPyVIXZ+m6bs7j1UVKP08Emv6jRmYrYqxYzO63mQxy1rw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-3.0.1.tgz",
+            "integrity": "sha512-5GIimz5IqaRsdnxs4YlyTZPwAMfALu/wA4jqSiuqgdbCxUZ2WjrnwANqOtoBJQgeaUTdYNfALJO0Yb0YrDqduA==",
             "dev": true
         },
         "node_modules/@types/d3-timer": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.0.tgz",
-            "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-2.0.1.tgz",
+            "integrity": "sha512-TF8aoF5cHcLO7W7403blM7L1T+6NF3XMyN3fxyUolq2uOcFeicG/khQg/dGxiCJWoAcmYulYN7LYSRKO54IXaA==",
             "dev": true
         },
         "node_modules/@types/d3-transition": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.1.tgz",
-            "integrity": "sha512-Sv4qEI9uq3bnZwlOANvYK853zvpdKEm1yz9rcc8ZTsxvRklcs9Fx4YFuGA3gXoQN/c/1T6QkVNjhaRO/cWj94g==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-2.0.2.tgz",
+            "integrity": "sha512-376TICEykdXOEA9uUIYpjshEkxfGwCPnkHUl8+6gphzKbf5NMnUhKT7wR59Yxrd9wtJ/rmE3SVLx6/8w4eY6Zg==",
             "dev": true,
             "dependencies": {
-                "@types/d3-selection": "*"
+                "@types/d3-selection": "^2"
             }
         },
         "node_modules/@types/d3-zoom": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.1.tgz",
-            "integrity": "sha512-7s5L9TjfqIYQmQQEUcpMAcBOahem7TRoSO/+Gkz02GbMVuULiZzjF2BOdw291dbO2aNon4m2OdFsRGaCq2caLQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-2.0.3.tgz",
+            "integrity": "sha512-9X9uDYKk2U8w775OHj36s9Q7GkNAnJKGw6+sbkP5DpHSjELwKvTGzEK6+IISYfLpJRL/V3mRXMhgDnnJ5LkwJg==",
             "dev": true,
             "dependencies": {
-                "@types/d3-interpolate": "*",
-                "@types/d3-selection": "*"
+                "@types/d3-interpolate": "^2",
+                "@types/d3-selection": "^2"
             }
         },
         "node_modules/@types/geojson": {
-            "version": "7946.0.8",
-            "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
-            "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==",
+            "version": "7946.0.10",
+            "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+            "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
             "dev": true
         },
         "node_modules/@types/graceful-fs": {
@@ -2440,12 +2440,9 @@
             }
         },
         "node_modules/commander": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-            "engines": {
-                "node": ">= 10"
-            }
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -2559,384 +2556,280 @@
             "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
         },
         "node_modules/d3": {
-            "version": "7.6.1",
-            "resolved": "https://registry.npmjs.org/d3/-/d3-7.6.1.tgz",
-            "integrity": "sha512-txMTdIHFbcpLx+8a0IFhZsbp+PfBBPt8yfbmukZTQFroKuFqIwqswF0qE5JXWefylaAVpSXFoKm3yP+jpNLFLw==",
+            "version": "6.7.0",
+            "resolved": "https://registry.npmjs.org/d3/-/d3-6.7.0.tgz",
+            "integrity": "sha512-hNHRhe+yCDLUG6Q2LwvR/WdNFPOJQ5VWqsJcwIYVeI401+d2/rrCjxSXkiAdIlpx7/73eApFB4Olsmh3YN7a6g==",
             "dependencies": {
-                "d3-array": "3",
-                "d3-axis": "3",
-                "d3-brush": "3",
-                "d3-chord": "3",
-                "d3-color": "3",
-                "d3-contour": "4",
-                "d3-delaunay": "6",
-                "d3-dispatch": "3",
-                "d3-drag": "3",
-                "d3-dsv": "3",
-                "d3-ease": "3",
-                "d3-fetch": "3",
-                "d3-force": "3",
-                "d3-format": "3",
-                "d3-geo": "3",
-                "d3-hierarchy": "3",
-                "d3-interpolate": "3",
-                "d3-path": "3",
-                "d3-polygon": "3",
-                "d3-quadtree": "3",
-                "d3-random": "3",
-                "d3-scale": "4",
-                "d3-scale-chromatic": "3",
-                "d3-selection": "3",
-                "d3-shape": "3",
-                "d3-time": "3",
-                "d3-time-format": "4",
-                "d3-timer": "3",
-                "d3-transition": "3",
-                "d3-zoom": "3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-array": "2",
+                "d3-axis": "2",
+                "d3-brush": "2",
+                "d3-chord": "2",
+                "d3-color": "2",
+                "d3-contour": "2",
+                "d3-delaunay": "5",
+                "d3-dispatch": "2",
+                "d3-drag": "2",
+                "d3-dsv": "2",
+                "d3-ease": "2",
+                "d3-fetch": "2",
+                "d3-force": "2",
+                "d3-format": "2",
+                "d3-geo": "2",
+                "d3-hierarchy": "2",
+                "d3-interpolate": "2",
+                "d3-path": "2",
+                "d3-polygon": "2",
+                "d3-quadtree": "2",
+                "d3-random": "2",
+                "d3-scale": "3",
+                "d3-scale-chromatic": "2",
+                "d3-selection": "2",
+                "d3-shape": "2",
+                "d3-time": "2",
+                "d3-time-format": "3",
+                "d3-timer": "2",
+                "d3-transition": "2",
+                "d3-zoom": "2"
             }
         },
         "node_modules/d3-array": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
-            "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+            "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
             "dependencies": {
-                "internmap": "1 - 2"
-            },
-            "engines": {
-                "node": ">=12"
+                "internmap": "^1.0.0"
             }
         },
         "node_modules/d3-axis": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
-            "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-2.1.0.tgz",
+            "integrity": "sha512-z/G2TQMyuf0X3qP+Mh+2PimoJD41VOCjViJzT0BHeL/+JQAofkiWZbWxlwFGb1N8EN+Cl/CW+MUKbVzr1689Cw=="
         },
         "node_modules/d3-brush": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
-            "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-2.1.0.tgz",
+            "integrity": "sha512-cHLLAFatBATyIKqZOkk/mDHUbzne2B3ZwxkzMHvFTCZCmLaXDpZRihQSn8UNXTkGD/3lb/W2sQz0etAftmHMJQ==",
             "dependencies": {
-                "d3-dispatch": "1 - 3",
-                "d3-drag": "2 - 3",
-                "d3-interpolate": "1 - 3",
-                "d3-selection": "3",
-                "d3-transition": "3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-dispatch": "1 - 2",
+                "d3-drag": "2",
+                "d3-interpolate": "1 - 2",
+                "d3-selection": "2",
+                "d3-transition": "2"
             }
         },
         "node_modules/d3-chord": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
-            "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-2.0.0.tgz",
+            "integrity": "sha512-D5PZb7EDsRNdGU4SsjQyKhja8Zgu+SHZfUSO5Ls8Wsn+jsAKUUGkcshLxMg9HDFxG3KqavGWaWkJ8EpU8ojuig==",
             "dependencies": {
-                "d3-path": "1 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-path": "1 - 2"
             }
         },
         "node_modules/d3-color": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+            "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
         },
         "node_modules/d3-contour": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.0.tgz",
-            "integrity": "sha512-7aQo0QHUTu/Ko3cP9YK9yUTxtoDEiDGwnBHyLxG5M4vqlBkO/uixMRele3nfsfj6UXOcuReVpVXzAboGraYIJw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-2.0.0.tgz",
+            "integrity": "sha512-9unAtvIaNk06UwqBmvsdHX7CZ+NPDZnn8TtNH1myW93pWJkhsV25JcgnYAu0Ck5Veb1DHiCv++Ic5uvJ+h50JA==",
             "dependencies": {
-                "d3-array": "^3.2.0"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-array": "2"
             }
         },
         "node_modules/d3-delaunay": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
-            "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
+            "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
             "dependencies": {
-                "delaunator": "5"
-            },
-            "engines": {
-                "node": ">=12"
+                "delaunator": "4"
             }
         },
         "node_modules/d3-dispatch": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
-            "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+            "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA=="
         },
         "node_modules/d3-drag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
-            "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
+            "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
             "dependencies": {
-                "d3-dispatch": "1 - 3",
-                "d3-selection": "3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-dispatch": "1 - 2",
+                "d3-selection": "2"
             }
         },
         "node_modules/d3-dsv": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
-            "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
+            "integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
             "dependencies": {
-                "commander": "7",
-                "iconv-lite": "0.6",
+                "commander": "2",
+                "iconv-lite": "0.4",
                 "rw": "1"
             },
             "bin": {
-                "csv2json": "bin/dsv2json.js",
-                "csv2tsv": "bin/dsv2dsv.js",
-                "dsv2dsv": "bin/dsv2dsv.js",
-                "dsv2json": "bin/dsv2json.js",
-                "json2csv": "bin/json2dsv.js",
-                "json2dsv": "bin/json2dsv.js",
-                "json2tsv": "bin/json2dsv.js",
-                "tsv2csv": "bin/dsv2dsv.js",
-                "tsv2json": "bin/dsv2json.js"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/d3-dsv/node_modules/iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
+                "csv2json": "bin/dsv2json",
+                "csv2tsv": "bin/dsv2dsv",
+                "dsv2dsv": "bin/dsv2dsv",
+                "dsv2json": "bin/dsv2json",
+                "json2csv": "bin/json2dsv",
+                "json2dsv": "bin/json2dsv",
+                "json2tsv": "bin/json2dsv",
+                "tsv2csv": "bin/dsv2dsv",
+                "tsv2json": "bin/dsv2json"
             }
         },
         "node_modules/d3-ease": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
+            "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ=="
         },
         "node_modules/d3-fetch": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
-            "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-2.0.0.tgz",
+            "integrity": "sha512-TkYv/hjXgCryBeNKiclrwqZH7Nb+GaOwo3Neg24ZVWA3MKB+Rd+BY84Nh6tmNEMcjUik1CSUWjXYndmeO6F7sw==",
             "dependencies": {
-                "d3-dsv": "1 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-dsv": "1 - 2"
             }
         },
         "node_modules/d3-force": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
-            "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.1.1.tgz",
+            "integrity": "sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==",
             "dependencies": {
-                "d3-dispatch": "1 - 3",
-                "d3-quadtree": "1 - 3",
-                "d3-timer": "1 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-dispatch": "1 - 2",
+                "d3-quadtree": "1 - 2",
+                "d3-timer": "1 - 2"
             }
         },
         "node_modules/d3-format": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-            "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+            "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
         },
         "node_modules/d3-geo": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.0.1.tgz",
-            "integrity": "sha512-Wt23xBych5tSy9IYAM1FR2rWIBFWa52B/oF/GYe5zbdHrg08FU8+BuI6X4PvTwPDdqdAdq04fuWJpELtsaEjeA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+            "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
             "dependencies": {
-                "d3-array": "2.5.0 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-array": "^2.5.0"
             }
         },
         "node_modules/d3-hierarchy": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
-            "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
+            "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw=="
         },
         "node_modules/d3-interpolate": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+            "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
             "dependencies": {
-                "d3-color": "1 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-color": "1 - 2"
             }
         },
         "node_modules/d3-path": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.0.1.tgz",
-            "integrity": "sha512-gq6gZom9AFZby0YLduxT1qmrp4xpBA1YZr19OI717WIdKE2OM5ETq5qrHLb301IgxhLwcuxvGZVLeeWc/k1I6w==",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+            "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
         },
         "node_modules/d3-polygon": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
-            "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-2.0.0.tgz",
+            "integrity": "sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ=="
         },
         "node_modules/d3-quadtree": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
-            "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
+            "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw=="
         },
         "node_modules/d3-random": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
-            "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-2.2.2.tgz",
+            "integrity": "sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw=="
         },
         "node_modules/d3-scale": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+            "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
             "dependencies": {
-                "d3-array": "2.10.0 - 3",
-                "d3-format": "1 - 3",
-                "d3-interpolate": "1.2.0 - 3",
-                "d3-time": "2.1.1 - 3",
-                "d3-time-format": "2 - 4"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-array": "^2.3.0",
+                "d3-format": "1 - 2",
+                "d3-interpolate": "1.2.0 - 2",
+                "d3-time": "^2.1.1",
+                "d3-time-format": "2 - 3"
             }
         },
         "node_modules/d3-scale-chromatic": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
-            "integrity": "sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
+            "integrity": "sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==",
             "dependencies": {
-                "d3-color": "1 - 3",
-                "d3-interpolate": "1 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-color": "1 - 2",
+                "d3-interpolate": "1 - 2"
             }
         },
         "node_modules/d3-selection": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-            "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
+            "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
         },
         "node_modules/d3-shape": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.1.0.tgz",
-            "integrity": "sha512-tGDh1Muf8kWjEDT/LswZJ8WF85yDZLvVJpYU9Nq+8+yW1Z5enxrmXOhTArlkaElU+CTn0OTVNli+/i+HP45QEQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
+            "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
             "dependencies": {
-                "d3-path": "1 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-path": "1 - 2"
             }
         },
         "node_modules/d3-time": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.0.0.tgz",
-            "integrity": "sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+            "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
             "dependencies": {
-                "d3-array": "2 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-array": "2"
             }
         },
         "node_modules/d3-time-format": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+            "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
             "dependencies": {
-                "d3-time": "1 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-time": "1 - 2"
             }
         },
         "node_modules/d3-timer": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+            "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA=="
         },
         "node_modules/d3-transition": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
-            "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
+            "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
             "dependencies": {
-                "d3-color": "1 - 3",
-                "d3-dispatch": "1 - 3",
-                "d3-ease": "1 - 3",
-                "d3-interpolate": "1 - 3",
-                "d3-timer": "1 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-color": "1 - 2",
+                "d3-dispatch": "1 - 2",
+                "d3-ease": "1 - 2",
+                "d3-interpolate": "1 - 2",
+                "d3-timer": "1 - 2"
             },
             "peerDependencies": {
-                "d3-selection": "2 - 3"
+                "d3-selection": "2"
             }
         },
         "node_modules/d3-zoom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
-            "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
+            "integrity": "sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==",
             "dependencies": {
-                "d3-dispatch": "1 - 3",
-                "d3-drag": "2 - 3",
-                "d3-interpolate": "1 - 3",
-                "d3-selection": "2 - 3",
-                "d3-transition": "2 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-dispatch": "1 - 2",
+                "d3-drag": "2",
+                "d3-interpolate": "1 - 2",
+                "d3-selection": "2",
+                "d3-transition": "2"
             }
         },
         "node_modules/data-urls": {
@@ -2999,12 +2892,9 @@
             }
         },
         "node_modules/delaunator": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
-            "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
-            "dependencies": {
-                "robust-predicates": "^3.0.0"
-            }
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+            "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
         },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
@@ -4060,12 +3950,9 @@
             "dev": true
         },
         "node_modules/internmap": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+            "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
         },
         "node_modules/is-core-module": {
             "version": "2.8.0",
@@ -5766,11 +5653,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
-        },
-        "node_modules/robust-predicates": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
-            "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g=="
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
@@ -7710,262 +7592,262 @@
             "dev": true
         },
         "@types/d3": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.1.0.tgz",
-            "integrity": "sha512-gYWvgeGjEl+zmF8c+U1RNIKqe7sfQwIXeLXO5Os72TjDjCEtgpvGBvZ8dXlAuSS1m6B90Y1Uo6Bm36OGR/OtCA==",
+            "version": "6.7.5",
+            "resolved": "https://registry.npmjs.org/@types/d3/-/d3-6.7.5.tgz",
+            "integrity": "sha512-TUZ6zuT/KIvbHSv81kwAiO5gG5aTuoiLGnWR/KxHJ15Idy/xmGUXaaF5zMG+UMIsndcGlSHTmrvwRgdvZlNKaA==",
             "dev": true,
             "requires": {
-                "@types/d3-array": "*",
-                "@types/d3-axis": "*",
-                "@types/d3-brush": "*",
-                "@types/d3-chord": "*",
-                "@types/d3-color": "*",
-                "@types/d3-contour": "*",
-                "@types/d3-delaunay": "*",
-                "@types/d3-dispatch": "*",
-                "@types/d3-drag": "*",
-                "@types/d3-dsv": "*",
-                "@types/d3-ease": "*",
-                "@types/d3-fetch": "*",
-                "@types/d3-force": "*",
-                "@types/d3-format": "*",
-                "@types/d3-geo": "*",
-                "@types/d3-hierarchy": "*",
-                "@types/d3-interpolate": "*",
-                "@types/d3-path": "*",
-                "@types/d3-polygon": "*",
-                "@types/d3-quadtree": "*",
-                "@types/d3-random": "*",
-                "@types/d3-scale": "*",
-                "@types/d3-scale-chromatic": "*",
-                "@types/d3-selection": "*",
-                "@types/d3-shape": "*",
-                "@types/d3-time": "*",
-                "@types/d3-time-format": "*",
-                "@types/d3-timer": "*",
-                "@types/d3-transition": "*",
-                "@types/d3-zoom": "*"
+                "@types/d3-array": "^2",
+                "@types/d3-axis": "^2",
+                "@types/d3-brush": "^2",
+                "@types/d3-chord": "^2",
+                "@types/d3-color": "^2",
+                "@types/d3-contour": "^2",
+                "@types/d3-delaunay": "^5",
+                "@types/d3-dispatch": "^2",
+                "@types/d3-drag": "^2",
+                "@types/d3-dsv": "^2",
+                "@types/d3-ease": "^2",
+                "@types/d3-fetch": "^2",
+                "@types/d3-force": "^2",
+                "@types/d3-format": "^2",
+                "@types/d3-geo": "^2",
+                "@types/d3-hierarchy": "^2",
+                "@types/d3-interpolate": "^2",
+                "@types/d3-path": "^2",
+                "@types/d3-polygon": "^2",
+                "@types/d3-quadtree": "^2",
+                "@types/d3-random": "^2",
+                "@types/d3-scale": "^3",
+                "@types/d3-scale-chromatic": "^2",
+                "@types/d3-selection": "^2",
+                "@types/d3-shape": "^2",
+                "@types/d3-time": "^2",
+                "@types/d3-time-format": "^3",
+                "@types/d3-timer": "^2",
+                "@types/d3-transition": "^2",
+                "@types/d3-zoom": "^2"
             }
         },
         "@types/d3-array": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.2.tgz",
-            "integrity": "sha512-5mjGjz6XOXKOCdTajXTZ/pMsg236RdiwKPrRPWAEf/2S/+PzwY+LLYShUpeysWaMvsdS7LArh6GdUefoxpchsQ==",
+            "version": "2.12.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-2.12.3.tgz",
+            "integrity": "sha512-hN879HLPTVqZV3FQEXy7ptt083UXwguNbnxdTGzVW4y4KjX5uyNKljrQixZcSJfLyFirbpUokxpXtvR+N5+KIg==",
             "dev": true
         },
         "@types/d3-axis": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.1.tgz",
-            "integrity": "sha512-zji/iIbdd49g9WN0aIsGcwcTBUkgLsCSwB+uH+LPVDAiKWENMtI3cJEWt+7/YYwelMoZmbBfzA3qCdrZ2XFNnw==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-2.1.3.tgz",
+            "integrity": "sha512-QjXjwZ0xzyrW2ndkmkb09ErgWDEYtbLBKGui73QLMFm3woqWpxptfD5Y7vqQdybMcu7WEbjZ5q+w2w5+uh2IjA==",
             "dev": true,
             "requires": {
-                "@types/d3-selection": "*"
+                "@types/d3-selection": "^2"
             }
         },
         "@types/d3-brush": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.1.tgz",
-            "integrity": "sha512-B532DozsiTuQMHu2YChdZU0qsFJSio3Q6jmBYGYNp3gMDzBmuFFgPt9qKA4VYuLZMp4qc6eX7IUFUEsvHiXZAw==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-2.1.2.tgz",
+            "integrity": "sha512-DnZmjdK1ycX1CMiW9r5E3xSf1tL+bp3yob1ON8bf0xB0/odfmGXeYOTafU+2SmU1F0/dvcqaO4SMjw62onOu6A==",
             "dev": true,
             "requires": {
-                "@types/d3-selection": "*"
+                "@types/d3-selection": "^2"
             }
         },
         "@types/d3-chord": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.1.tgz",
-            "integrity": "sha512-eQfcxIHrg7V++W8Qxn6QkqBNBokyhdWSAS73AbkbMzvLQmVVBviknoz2SRS/ZJdIOmhcmmdCRE/NFOm28Z1AMw==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-2.0.3.tgz",
+            "integrity": "sha512-koIqSNQLPRQPXt7c55hgRF6Lr9Ps72r1+Biv55jdYR+SHJ463MsB2lp4ktzttFNmrQw/9yWthf/OmSUj5dNXKw==",
             "dev": true
         },
         "@types/d3-color": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.0.2.tgz",
-            "integrity": "sha512-WVx6zBiz4sWlboCy7TCgjeyHpNjMsoF36yaagny1uXfbadc9f+5BeBf7U+lRmQqY3EHbGQpP8UdW8AC+cywSwQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-2.0.3.tgz",
+            "integrity": "sha512-+0EtEjBfKEDtH9Rk3u3kLOUXM5F+iZK+WvASPb0MhIZl8J8NUvGeZRwKCXl+P3HkYx5TdU4YtcibpqHkSR9n7w==",
             "dev": true
         },
         "@types/d3-contour": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.1.tgz",
-            "integrity": "sha512-C3zfBrhHZvrpAAK3YXqLWVAGo87A4SvJ83Q/zVJ8rFWJdKejUnDYaWZPkA8K84kb2vDA/g90LTQAz7etXcgoQQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-2.0.4.tgz",
+            "integrity": "sha512-WMac1xV/mXAgkgr5dUvzsBV5OrgNZDBDpJk9s3v2SadTqGgDRirKABb2Ek2H1pFlYVH4Oly9XJGnuzxKDduqWA==",
             "dev": true,
             "requires": {
-                "@types/d3-array": "*",
+                "@types/d3-array": "^2",
                 "@types/geojson": "*"
             }
         },
         "@types/d3-delaunay": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.0.tgz",
-            "integrity": "sha512-iGm7ZaGLq11RK3e69VeMM6Oqj2SjKUB9Qhcyd1zIcqn2uE8w9GFB445yCY46NOQO3ByaNyktX1DK+Etz7ZaX+w==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-5.3.1.tgz",
+            "integrity": "sha512-F6itHi2DxdatHil1rJ2yEFUNhejj8+0Acd55LZ6Ggwbdoks0+DxVY2cawNj16sjCBiWvubVlh6eBMVsYRNGLew==",
             "dev": true
         },
         "@types/d3-dispatch": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
-            "integrity": "sha512-NhxMn3bAkqhjoxabVJWKryhnZXXYYVQxaBnbANu0O94+O/nX9qSjrA1P1jbAQJxJf+VC72TxDX/YJcKue5bRqw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-2.0.1.tgz",
+            "integrity": "sha512-eT2K8uG3rXkmRiCpPn0rNrekuSLdBfV83vbTvfZliA5K7dbeaqWS/CBHtJ9SQoF8aDTsWSY4A0RU67U/HcKdJQ==",
             "dev": true
         },
         "@types/d3-drag": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.1.tgz",
-            "integrity": "sha512-o1Va7bLwwk6h03+nSM8dpaGEYnoIG19P0lKqlic8Un36ymh9NSkNFX1yiXMKNMx8rJ0Kfnn2eovuFaL6Jvj0zA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-2.0.2.tgz",
+            "integrity": "sha512-m9USoFaTgVw2mmE7vLjWTApT9dMxMlql/dl3Gj503x+1a2n6K455iDWydqy2dfCpkUBCoF82yRGDgcSk9FUEyQ==",
             "dev": true,
             "requires": {
-                "@types/d3-selection": "*"
+                "@types/d3-selection": "^2"
             }
         },
         "@types/d3-dsv": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.0.tgz",
-            "integrity": "sha512-o0/7RlMl9p5n6FQDptuJVMxDf/7EDEv2SYEO/CwdG2tr1hTfUVi0Iavkk2ax+VpaQ/1jVhpnj5rq1nj8vwhn2A==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-2.0.3.tgz",
+            "integrity": "sha512-15sp4Z+ZVWuZuV0QEDu4cu/0C5vlD+JYXaUMDs8JTWpTJjcrAtjyR1vVwEfbgmU5kLNOOMRTlDCYyWWFx7eh/w==",
             "dev": true
         },
         "@types/d3-ease": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.0.tgz",
-            "integrity": "sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-2.0.2.tgz",
+            "integrity": "sha512-29Y73Tg6o6aL+3/S/kEun84m5BO4bjRNau6pMWv9N9rZHcJv/O/07mW6EjqxrePZZS64fj0wiB5LMHr4Jzf3eQ==",
             "dev": true
         },
         "@types/d3-fetch": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.1.tgz",
-            "integrity": "sha512-toZJNOwrOIqz7Oh6Q7l2zkaNfXkfR7mFSJvGvlD/Ciq/+SQ39d5gynHJZ/0fjt83ec3WL7+u3ssqIijQtBISsw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-2.0.2.tgz",
+            "integrity": "sha512-sllsCSWrNdSvzOJWN5RnxkmtvW9pCttONGajSxHX9FUQ9kOkGE391xlz6VDBdZxLnpwjp3I+mipbwsaCjq4m5A==",
             "dev": true,
             "requires": {
-                "@types/d3-dsv": "*"
+                "@types/d3-dsv": "^2"
             }
         },
         "@types/d3-force": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.3.tgz",
-            "integrity": "sha512-z8GteGVfkWJMKsx6hwC3SiTSLspL98VNpmvLpEFJQpZPq6xpA1I8HNBDNSpukfK0Vb0l64zGFhzunLgEAcBWSA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-2.1.4.tgz",
+            "integrity": "sha512-1XVRc2QbeUSL1FRVE53Irdz7jY+drTwESHIMVirCwkAAMB/yVC8ezAfx/1Alq0t0uOnphoyhRle1ht5CuPgSJQ==",
             "dev": true
         },
         "@types/d3-format": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz",
-            "integrity": "sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-2.0.2.tgz",
+            "integrity": "sha512-OhQPuTeeMhD9A0Ksqo4q1S9Z1Q57O/t4tTPBxBQxRB4IERnxeoEYLPe72fA/GYpPSUrfKZVOgLHidkxwbzLdJA==",
             "dev": true
         },
         "@types/d3-geo": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.0.2.tgz",
-            "integrity": "sha512-DbqK7MLYA8LpyHQfv6Klz0426bQEf7bRTvhMy44sNGVyZoWn//B0c+Qbeg8Osi2Obdc9BLLXYAKpyWege2/7LQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-2.0.4.tgz",
+            "integrity": "sha512-kP0LcPVN6P/42hmFt0kZm93YTscfawZo6tioL9y0Ya2l5rxaGoYrIG4zee+yJoK9cLTOc8E8S5ExqTEYVwjIkw==",
             "dev": true,
             "requires": {
                 "@types/geojson": "*"
             }
         },
         "@types/d3-hierarchy": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.0.2.tgz",
-            "integrity": "sha512-+krnrWOZ+aQB6v+E+jEkmkAx9HvsNAD+1LCD0vlBY3t+HwjKnsBFbpVLx6WWzDzCIuiTWdAxXMEnGnVXpB09qQ==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-2.0.2.tgz",
+            "integrity": "sha512-6PlBRwbjUPPt0ZFq/HTUyOAdOF3p73EUYots74lHMUyAVtdFSOS/hAeNXtEIM9i7qRDntuIblXxHGUMb9MuNRA==",
             "dev": true
         },
         "@types/d3-interpolate": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-            "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-2.0.2.tgz",
+            "integrity": "sha512-lElyqlUfIPyWG/cD475vl6msPL4aMU7eJvx1//Q177L8mdXoVPFl1djIESF2FKnc0NyaHvQlJpWwKJYwAhUoCw==",
             "dev": true,
             "requires": {
-                "@types/d3-color": "*"
+                "@types/d3-color": "^2"
             }
         },
         "@types/d3-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.0.tgz",
-            "integrity": "sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.2.tgz",
+            "integrity": "sha512-3YHpvDw9LzONaJzejXLOwZ3LqwwkoXb9LI2YN7Hbd6pkGo5nIlJ09ul4bQhBN4hQZJKmUpX8HkVqbzgUKY48cg==",
             "dev": true
         },
         "@types/d3-polygon": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.0.tgz",
-            "integrity": "sha512-D49z4DyzTKXM0sGKVqiTDTYr+DHg/uxsiWDAkNrwXYuiZVd9o9wXZIo+YsHkifOiyBkmSWlEngHCQme54/hnHw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-2.0.1.tgz",
+            "integrity": "sha512-X3XTIwBxlzRIWe4yaD1KsmcfItjSPLTGL04QDyP08jyHDVsnz3+NZJMwtD4vCaTAVpGSjbqS+jrBo8cO2V/xMA==",
             "dev": true
         },
         "@types/d3-quadtree": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.2.tgz",
-            "integrity": "sha512-QNcK8Jguvc8lU+4OfeNx+qnVy7c0VrDJ+CCVFS9srBo2GL9Y18CnIxBdTF3v38flrGy5s1YggcoAiu6s4fLQIw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-2.0.2.tgz",
+            "integrity": "sha512-KgWL4jlz8QJJZX01E4HKXJ9FLU94RTuObsAYqsPp8YOAcYDmEgJIQJ+ojZcnKUAnrUb78ik8JBKWas5XZPqJnQ==",
             "dev": true
         },
         "@types/d3-random": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.1.tgz",
-            "integrity": "sha512-IIE6YTekGczpLYo/HehAy3JGF1ty7+usI97LqraNa8IiDur+L44d0VOjAvFQWJVdZOJHukUJw+ZdZBlgeUsHOQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-2.2.1.tgz",
+            "integrity": "sha512-5vvxn6//poNeOxt1ZwC7QU//dG9QqABjy1T7fP/xmFHY95GnaOw3yABf29hiu5SR1Oo34XcpyHFbzod+vemQjA==",
             "dev": true
         },
         "@types/d3-scale": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.2.tgz",
-            "integrity": "sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.3.2.tgz",
+            "integrity": "sha512-gGqr7x1ost9px3FvIfUMi5XA/F/yAf4UkUDtdQhpH92XCT0Oa7zkkRzY61gPVJq+DxpHn/btouw5ohWkbBsCzQ==",
             "dev": true,
             "requires": {
-                "@types/d3-time": "*"
+                "@types/d3-time": "^2"
             }
         },
         "@types/d3-scale-chromatic": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
-            "integrity": "sha512-dsoJGEIShosKVRBZB0Vo3C8nqSDqVGujJU6tPznsBJxNJNwMF8utmS83nvCBKQYPpjCzaaHcrf66iTRpZosLPw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-2.0.1.tgz",
+            "integrity": "sha512-3EuZlbPu+pvclZcb1DhlymTWT2W+lYsRKBjvkH2ojDbCWDYavifqu1vYX9WGzlPgCgcS4Alhk1+zapXbGEGylQ==",
             "dev": true
         },
         "@types/d3-selection": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.1.tgz",
-            "integrity": "sha512-aJ1d1SCUtERHH65bB8NNoLpUOI3z8kVcfg2BGm4rMMUwuZF4x6qnIEKjT60Vt0o7gP/a/xkRVs4D9CpDifbyRA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-2.0.1.tgz",
+            "integrity": "sha512-3mhtPnGE+c71rl/T5HMy+ykg7migAZ4T6gzU0HxpgBFKcasBrSnwRbYV1/UZR6o5fkpySxhWxAhd7yhjj8jL7g==",
             "dev": true
         },
         "@types/d3-shape": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.0.2.tgz",
-            "integrity": "sha512-5+ButCmIfNX8id5seZ7jKj3igdcxx+S9IDBiT35fQGTLZUfkFgTv+oBH34xgeoWDKpWcMITSzBILWQtBoN5Piw==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.1.3.tgz",
+            "integrity": "sha512-HAhCel3wP93kh4/rq+7atLdybcESZ5bRHDEZUojClyZWsRuEMo3A52NGYJSh48SxfxEU6RZIVbZL2YFZ2OAlzQ==",
             "dev": true,
             "requires": {
-                "@types/d3-path": "*"
+                "@types/d3-path": "^2"
             }
         },
         "@types/d3-time": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
-            "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.1.1.tgz",
+            "integrity": "sha512-9MVYlmIgmRR31C5b4FVSWtuMmBHh2mOWQYfl7XAYOa8dsnb7iEmUmRSWSFgXFtkjxO65d7hTUHQC+RhR/9IWFg==",
             "dev": true
         },
         "@types/d3-time-format": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.0.tgz",
-            "integrity": "sha512-yjfBUe6DJBsDin2BMIulhSHmr5qNR5Pxs17+oW4DoVPyVIXZ+m6bs7j1UVKP08Emv6jRmYrYqxYzO63mQxy1rw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-3.0.1.tgz",
+            "integrity": "sha512-5GIimz5IqaRsdnxs4YlyTZPwAMfALu/wA4jqSiuqgdbCxUZ2WjrnwANqOtoBJQgeaUTdYNfALJO0Yb0YrDqduA==",
             "dev": true
         },
         "@types/d3-timer": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.0.tgz",
-            "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-2.0.1.tgz",
+            "integrity": "sha512-TF8aoF5cHcLO7W7403blM7L1T+6NF3XMyN3fxyUolq2uOcFeicG/khQg/dGxiCJWoAcmYulYN7LYSRKO54IXaA==",
             "dev": true
         },
         "@types/d3-transition": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.1.tgz",
-            "integrity": "sha512-Sv4qEI9uq3bnZwlOANvYK853zvpdKEm1yz9rcc8ZTsxvRklcs9Fx4YFuGA3gXoQN/c/1T6QkVNjhaRO/cWj94g==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-2.0.2.tgz",
+            "integrity": "sha512-376TICEykdXOEA9uUIYpjshEkxfGwCPnkHUl8+6gphzKbf5NMnUhKT7wR59Yxrd9wtJ/rmE3SVLx6/8w4eY6Zg==",
             "dev": true,
             "requires": {
-                "@types/d3-selection": "*"
+                "@types/d3-selection": "^2"
             }
         },
         "@types/d3-zoom": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.1.tgz",
-            "integrity": "sha512-7s5L9TjfqIYQmQQEUcpMAcBOahem7TRoSO/+Gkz02GbMVuULiZzjF2BOdw291dbO2aNon4m2OdFsRGaCq2caLQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-2.0.3.tgz",
+            "integrity": "sha512-9X9uDYKk2U8w775OHj36s9Q7GkNAnJKGw6+sbkP5DpHSjELwKvTGzEK6+IISYfLpJRL/V3mRXMhgDnnJ5LkwJg==",
             "dev": true,
             "requires": {
-                "@types/d3-interpolate": "*",
-                "@types/d3-selection": "*"
+                "@types/d3-interpolate": "^2",
+                "@types/d3-selection": "^2"
             }
         },
         "@types/geojson": {
-            "version": "7946.0.8",
-            "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
-            "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==",
+            "version": "7946.0.10",
+            "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+            "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
             "dev": true
         },
         "@types/graceful-fs": {
@@ -8679,9 +8561,9 @@
             }
         },
         "commander": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
         },
         "concat-map": {
             "version": "0.0.1",
@@ -8786,276 +8668,266 @@
             }
         },
         "d3": {
-            "version": "7.6.1",
-            "resolved": "https://registry.npmjs.org/d3/-/d3-7.6.1.tgz",
-            "integrity": "sha512-txMTdIHFbcpLx+8a0IFhZsbp+PfBBPt8yfbmukZTQFroKuFqIwqswF0qE5JXWefylaAVpSXFoKm3yP+jpNLFLw==",
+            "version": "6.7.0",
+            "resolved": "https://registry.npmjs.org/d3/-/d3-6.7.0.tgz",
+            "integrity": "sha512-hNHRhe+yCDLUG6Q2LwvR/WdNFPOJQ5VWqsJcwIYVeI401+d2/rrCjxSXkiAdIlpx7/73eApFB4Olsmh3YN7a6g==",
             "requires": {
-                "d3-array": "3",
-                "d3-axis": "3",
-                "d3-brush": "3",
-                "d3-chord": "3",
-                "d3-color": "3",
-                "d3-contour": "4",
-                "d3-delaunay": "6",
-                "d3-dispatch": "3",
-                "d3-drag": "3",
-                "d3-dsv": "3",
-                "d3-ease": "3",
-                "d3-fetch": "3",
-                "d3-force": "3",
-                "d3-format": "3",
-                "d3-geo": "3",
-                "d3-hierarchy": "3",
-                "d3-interpolate": "3",
-                "d3-path": "3",
-                "d3-polygon": "3",
-                "d3-quadtree": "3",
-                "d3-random": "3",
-                "d3-scale": "4",
-                "d3-scale-chromatic": "3",
-                "d3-selection": "3",
-                "d3-shape": "3",
-                "d3-time": "3",
-                "d3-time-format": "4",
-                "d3-timer": "3",
-                "d3-transition": "3",
-                "d3-zoom": "3"
+                "d3-array": "2",
+                "d3-axis": "2",
+                "d3-brush": "2",
+                "d3-chord": "2",
+                "d3-color": "2",
+                "d3-contour": "2",
+                "d3-delaunay": "5",
+                "d3-dispatch": "2",
+                "d3-drag": "2",
+                "d3-dsv": "2",
+                "d3-ease": "2",
+                "d3-fetch": "2",
+                "d3-force": "2",
+                "d3-format": "2",
+                "d3-geo": "2",
+                "d3-hierarchy": "2",
+                "d3-interpolate": "2",
+                "d3-path": "2",
+                "d3-polygon": "2",
+                "d3-quadtree": "2",
+                "d3-random": "2",
+                "d3-scale": "3",
+                "d3-scale-chromatic": "2",
+                "d3-selection": "2",
+                "d3-shape": "2",
+                "d3-time": "2",
+                "d3-time-format": "3",
+                "d3-timer": "2",
+                "d3-transition": "2",
+                "d3-zoom": "2"
             }
         },
         "d3-array": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
-            "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+            "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
             "requires": {
-                "internmap": "1 - 2"
+                "internmap": "^1.0.0"
             }
         },
         "d3-axis": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
-            "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-2.1.0.tgz",
+            "integrity": "sha512-z/G2TQMyuf0X3qP+Mh+2PimoJD41VOCjViJzT0BHeL/+JQAofkiWZbWxlwFGb1N8EN+Cl/CW+MUKbVzr1689Cw=="
         },
         "d3-brush": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
-            "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-2.1.0.tgz",
+            "integrity": "sha512-cHLLAFatBATyIKqZOkk/mDHUbzne2B3ZwxkzMHvFTCZCmLaXDpZRihQSn8UNXTkGD/3lb/W2sQz0etAftmHMJQ==",
             "requires": {
-                "d3-dispatch": "1 - 3",
-                "d3-drag": "2 - 3",
-                "d3-interpolate": "1 - 3",
-                "d3-selection": "3",
-                "d3-transition": "3"
+                "d3-dispatch": "1 - 2",
+                "d3-drag": "2",
+                "d3-interpolate": "1 - 2",
+                "d3-selection": "2",
+                "d3-transition": "2"
             }
         },
         "d3-chord": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
-            "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-2.0.0.tgz",
+            "integrity": "sha512-D5PZb7EDsRNdGU4SsjQyKhja8Zgu+SHZfUSO5Ls8Wsn+jsAKUUGkcshLxMg9HDFxG3KqavGWaWkJ8EpU8ojuig==",
             "requires": {
-                "d3-path": "1 - 3"
+                "d3-path": "1 - 2"
             }
         },
         "d3-color": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+            "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
         },
         "d3-contour": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.0.tgz",
-            "integrity": "sha512-7aQo0QHUTu/Ko3cP9YK9yUTxtoDEiDGwnBHyLxG5M4vqlBkO/uixMRele3nfsfj6UXOcuReVpVXzAboGraYIJw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-2.0.0.tgz",
+            "integrity": "sha512-9unAtvIaNk06UwqBmvsdHX7CZ+NPDZnn8TtNH1myW93pWJkhsV25JcgnYAu0Ck5Veb1DHiCv++Ic5uvJ+h50JA==",
             "requires": {
-                "d3-array": "^3.2.0"
+                "d3-array": "2"
             }
         },
         "d3-delaunay": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
-            "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
+            "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
             "requires": {
-                "delaunator": "5"
+                "delaunator": "4"
             }
         },
         "d3-dispatch": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
-            "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+            "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA=="
         },
         "d3-drag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
-            "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
+            "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
             "requires": {
-                "d3-dispatch": "1 - 3",
-                "d3-selection": "3"
+                "d3-dispatch": "1 - 2",
+                "d3-selection": "2"
             }
         },
         "d3-dsv": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
-            "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
+            "integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
             "requires": {
-                "commander": "7",
-                "iconv-lite": "0.6",
+                "commander": "2",
+                "iconv-lite": "0.4",
                 "rw": "1"
-            },
-            "dependencies": {
-                "iconv-lite": {
-                    "version": "0.6.3",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-                    "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3.0.0"
-                    }
-                }
             }
         },
         "d3-ease": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
+            "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ=="
         },
         "d3-fetch": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
-            "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-2.0.0.tgz",
+            "integrity": "sha512-TkYv/hjXgCryBeNKiclrwqZH7Nb+GaOwo3Neg24ZVWA3MKB+Rd+BY84Nh6tmNEMcjUik1CSUWjXYndmeO6F7sw==",
             "requires": {
-                "d3-dsv": "1 - 3"
+                "d3-dsv": "1 - 2"
             }
         },
         "d3-force": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
-            "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.1.1.tgz",
+            "integrity": "sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==",
             "requires": {
-                "d3-dispatch": "1 - 3",
-                "d3-quadtree": "1 - 3",
-                "d3-timer": "1 - 3"
+                "d3-dispatch": "1 - 2",
+                "d3-quadtree": "1 - 2",
+                "d3-timer": "1 - 2"
             }
         },
         "d3-format": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-            "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+            "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
         },
         "d3-geo": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.0.1.tgz",
-            "integrity": "sha512-Wt23xBych5tSy9IYAM1FR2rWIBFWa52B/oF/GYe5zbdHrg08FU8+BuI6X4PvTwPDdqdAdq04fuWJpELtsaEjeA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+            "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
             "requires": {
-                "d3-array": "2.5.0 - 3"
+                "d3-array": "^2.5.0"
             }
         },
         "d3-hierarchy": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
-            "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
+            "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw=="
         },
         "d3-interpolate": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+            "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
             "requires": {
-                "d3-color": "1 - 3"
+                "d3-color": "1 - 2"
             }
         },
         "d3-path": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.0.1.tgz",
-            "integrity": "sha512-gq6gZom9AFZby0YLduxT1qmrp4xpBA1YZr19OI717WIdKE2OM5ETq5qrHLb301IgxhLwcuxvGZVLeeWc/k1I6w=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+            "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
         },
         "d3-polygon": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
-            "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-2.0.0.tgz",
+            "integrity": "sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ=="
         },
         "d3-quadtree": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
-            "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
+            "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw=="
         },
         "d3-random": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
-            "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-2.2.2.tgz",
+            "integrity": "sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw=="
         },
         "d3-scale": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+            "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
             "requires": {
-                "d3-array": "2.10.0 - 3",
-                "d3-format": "1 - 3",
-                "d3-interpolate": "1.2.0 - 3",
-                "d3-time": "2.1.1 - 3",
-                "d3-time-format": "2 - 4"
+                "d3-array": "^2.3.0",
+                "d3-format": "1 - 2",
+                "d3-interpolate": "1.2.0 - 2",
+                "d3-time": "^2.1.1",
+                "d3-time-format": "2 - 3"
             }
         },
         "d3-scale-chromatic": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
-            "integrity": "sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
+            "integrity": "sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==",
             "requires": {
-                "d3-color": "1 - 3",
-                "d3-interpolate": "1 - 3"
+                "d3-color": "1 - 2",
+                "d3-interpolate": "1 - 2"
             }
         },
         "d3-selection": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-            "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
+            "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
         },
         "d3-shape": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.1.0.tgz",
-            "integrity": "sha512-tGDh1Muf8kWjEDT/LswZJ8WF85yDZLvVJpYU9Nq+8+yW1Z5enxrmXOhTArlkaElU+CTn0OTVNli+/i+HP45QEQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
+            "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
             "requires": {
-                "d3-path": "1 - 3"
+                "d3-path": "1 - 2"
             }
         },
         "d3-time": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.0.0.tgz",
-            "integrity": "sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+            "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
             "requires": {
-                "d3-array": "2 - 3"
+                "d3-array": "2"
             }
         },
         "d3-time-format": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+            "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
             "requires": {
-                "d3-time": "1 - 3"
+                "d3-time": "1 - 2"
             }
         },
         "d3-timer": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+            "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA=="
         },
         "d3-transition": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
-            "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
+            "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
             "requires": {
-                "d3-color": "1 - 3",
-                "d3-dispatch": "1 - 3",
-                "d3-ease": "1 - 3",
-                "d3-interpolate": "1 - 3",
-                "d3-timer": "1 - 3"
+                "d3-color": "1 - 2",
+                "d3-dispatch": "1 - 2",
+                "d3-ease": "1 - 2",
+                "d3-interpolate": "1 - 2",
+                "d3-timer": "1 - 2"
             }
         },
         "d3-zoom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
-            "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
+            "integrity": "sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==",
             "requires": {
-                "d3-dispatch": "1 - 3",
-                "d3-drag": "2 - 3",
-                "d3-interpolate": "1 - 3",
-                "d3-selection": "2 - 3",
-                "d3-transition": "2 - 3"
+                "d3-dispatch": "1 - 2",
+                "d3-drag": "2",
+                "d3-interpolate": "1 - 2",
+                "d3-selection": "2",
+                "d3-transition": "2"
             }
         },
         "data-urls": {
@@ -9106,12 +8978,9 @@
             "dev": true
         },
         "delaunator": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
-            "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
-            "requires": {
-                "robust-predicates": "^3.0.0"
-            }
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+            "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
         },
         "delayed-stream": {
             "version": "1.0.0",
@@ -9877,9 +9746,9 @@
             "dev": true
         },
         "internmap": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+            "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
         },
         "is-core-module": {
             "version": "2.8.0",
@@ -11167,11 +11036,6 @@
             "requires": {
                 "glob": "^7.1.3"
             }
-        },
-        "robust-predicates": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
-            "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g=="
         },
         "run-parallel": {
             "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "@actions/github": "^5.0.0",
         "axios": "^0.21.3",
         "childprocess": "^2.0.2",
-        "d3": "^7.6.1",
+        "d3": "^6.7.0",
         "dotenv": "^8.2.0",
         "jest-junit": "^14.0.0",
         "js-abbreviation-number": "^1.4.0",
@@ -32,7 +32,7 @@
         "retry-axios": "^2.6.0"
     },
     "devDependencies": {
-        "@types/d3": "^7.1.0",
+        "@types/d3": "^6.7.0",
         "@types/jest": "^27.0.2",
         "@types/jsdom": "^16.2.13",
         "@types/node": "^16.11.6",


### PR DESCRIPTION
May not be working after merged #109 😢 

```
$ npm run build

> github-profile-summary-cards@0.5.2 build
> tsc

$ npm run run yamashush 9

> github-profile-summary-cards@0.5.2 run
> node -r dotenv/config lib/app.js yamashush 9

/Users/yamashu/dev/github-profile-summary-cards/lib/templates/card.js:23
const d3 = __importStar(require("d3"));
                        ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/yamashu/dev/github-profile-summary-cards/node_modules/d3/src/index.js from /Users/yamashu/dev/github-profile-summary-cards/lib/templates/card.js not supported.
Instead change the require of index.js in /Users/yamashu/dev/github-profile-summary-cards/lib/templates/card.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/Users/yamashu/dev/github-profile-summary-cards/lib/templates/card.js:23:25)
    at Object.<anonymous> (/Users/yamashu/dev/github-profile-summary-cards/lib/templates/profile-details-card.js:26:16)
    at Object.<anonymous> (/Users/yamashu/dev/github-profile-summary-cards/lib/cards/profile-details-card.js:18:32)
    at Object.<anonymous> (/Users/yamashu/dev/github-profile-summary-cards/lib/app.js:32:32) {
  code: 'ERR_REQUIRE_ESM'
}
```

`d3` v7.0.0 have several breaking changes.
https://github.com/d3/d3/releases/tag/v7.0.0

I just checked that it worked when I switched back to v6.