### PR TITLE
fix: Fix typo in input parameter

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -40,7 +40,7 @@ const action = async () => {
     core.info(`Username: ${username}`);
     const utcOffset = Number(core.getInput('UTC_OFFSET', {required: false}));
     core.info(`UTC offset: ${utcOffset}`);
-    const exclude = core.getInput('EXCLUE', {required: false}).split(',');
+    const exclude = core.getInput('EXCLUDE', {required: false}).split(',');
     core.info(`Excluded languages: ${exclude}`);
     try {
         // Remove old output


### PR DESCRIPTION
The exclude parameter was not read due to a typo and has been fixed.

If you have any problems, please let me know.