### PR TITLE
Add clarification on using '%20' to represent spaces in language exclusion list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@
   - username
     - Username
   - exclude:
-    - A comma separated list of languages to exclude, e.g., exclude=java,rust
+    - A comma separated list of languages to exclude, e.g., exclude=java,rust,jupyter%20notebook
+      - You can represent a space in the language list by using '%20' when you want to include a space.
     - You can found the supported languages in [here](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml)
 
 ### Top languages in commits card
@@ -83,7 +84,8 @@
   - username
     - Username
   - exclude:
-    - A comma separated list of languages to exclude, e.g., exclude=java,rust
+    - A comma separated list of languages to exclude, e.g., exclude=java,rust,jupyter%20notebook
+      - You can represent a space in the language list by using '%20' when you want to include a space.
     - You can found the supported languages in [here](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml)
 
 ### GitHub stats card


### PR DESCRIPTION
## What
- https://github.com/vn7n24fzkq/github-profile-summary-cards/issues/155
- Add clarification on using '%20' to represent spaces in language exclusion list in README.
## Why
- The purpose of this change is to make it easier for users to input spaces when specifying languages in the exclusion list.
## How
- Add a language that includes spaces in the input example.
- Added a note under the input example on lines 73 and 86 in README.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the README.md to clarify the usage of the `exclude` parameter, including additional examples and formatting guidelines for excluding languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->