### PR TITLE
docs(readme): Fix a typo in jupyter notebook in language exclusion lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@
   - username
     - Username
   - exclude:
-    - A comma separated list of languages to exclude, e.g., exclude=java,rust,jupyter%20notebook
+    - A comma separated list of languages to exclude, e.g., exclude=java,rust,jupyter%20Notebook
       - You can represent a space in the language list by using '%20' when you want to include a space.
     - You can found the supported languages in [here](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml)
 
@@ -84,7 +84,7 @@
   - username
     - Username
   - exclude:
-    - A comma separated list of languages to exclude, e.g., exclude=java,rust,jupyter%20notebook
+    - A comma separated list of languages to exclude, e.g., exclude=java,rust,jupyter%20Notebook
       - You can represent a space in the language list by using '%20' when you want to include a space.
     - You can found the supported languages in [here](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml)
 


### PR DESCRIPTION
Just a small correction as `jupyter%20notebook` doesn't work to exclude jupyter notebooks but `jupyter%20Notebook` does.

See:
- https://github-profile-summary-cards.vercel.app/api/cards/most-commit-language?username=louis-thevenet&theme=github&exclude=jupyter%20notebook

- https://github-profile-summary-cards.vercel.app/api/cards/most-commit-language?username=louis-thevenet&theme=github&exclude=jupyter%20Notebook

This problem seems to occur when spaces are involved in the language name. Maybe you should just make everything lowercase when comparing language names?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected casing of "Notebook" in examples for the "exclude" parameter to enhance clarity and consistency.
	- Maintained overall structure and content of the README, ensuring guidance on generating GitHub profile summary cards remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->