### PR TITLE
chore: add simple release ci

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,34 @@
+name: Manual Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Release Target'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - web-release
+          - release
+      tag_name:
+        description: 'Tag Name (e.g. v1.0.0). Required for action release.'
+        required: false
+
+jobs:
+  release-web:
+    if: github.event.inputs.target == 'all' || github.event.inputs.target == 'web-release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Sync main to web-release
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git push -f origin HEAD:web-release


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enable manual releases through the repository's Actions tab. The workflow allows maintainers to trigger releases for different targets, such as `all`, `web-release`, or `release`, and includes an option to specify a tag name for releases.

Release workflow automation:

* Added a new workflow file `.github/workflows/manual-release.yml` that defines a manual release process using `workflow_dispatch` with configurable inputs for target and tag name.
* Implemented a `release-web` job that syncs the `main` branch to the `web-release` branch using a force push, automating part of the release process for web deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new manual release workflow enabling controlled deployments with configurable targeting options and optional version tagging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->