### PR TITLE
fix: correct GA4 event names and make analytics non-blocking

### DIFF
--- a/api/cards/most-commit-language.ts
+++ b/api/cards/most-commit-language.ts
@@ -33,10 +33,11 @@ export default async (req: VercelRequest, res: VercelResponse) => {
         while (true) {
             try {
                 const cardSVG = await getCommitsLanguageSVGWithThemeName(username, theme, excludeArr, token);
-                await sendAnalytics('most-commit-language-card', {username, theme}, req.headers);
                 res.setHeader('Content-Type', 'image/svg+xml');
                 res.setHeader('Cache-Control', CONST_CACHE_CONTROL);
                 res.send(cardSVG);
+                // Fire-and-forget: don't block the response on analytics
+                void sendAnalytics('most_commit_language_card', {username, theme}, req.headers);
                 return;
             } catch (err: any) {
                 console.log(err.message);

--- a/api/cards/productive-time.ts
+++ b/api/cards/productive-time.ts
@@ -25,10 +25,11 @@ export default async (req: VercelRequest, res: VercelResponse) => {
         while (true) {
             try {
                 const cardSVG = await getProductiveTimeSVGWithThemeName(username, theme, Number(utcOffset), token);
-                await sendAnalytics('productive-time-card', {username, theme, utcOffset}, req.headers);
                 res.setHeader('Content-Type', 'image/svg+xml');
                 res.setHeader('Cache-Control', CONST_CACHE_CONTROL);
                 res.send(cardSVG);
+                // Fire-and-forget: don't block the response on analytics
+                void sendAnalytics('productive_time_card', {username, theme, utcOffset}, req.headers);
                 return;
             } catch (err: any) {
                 console.log(err.message);

--- a/api/cards/profile-details.ts
+++ b/api/cards/profile-details.ts
@@ -21,10 +21,11 @@ export default async (req: VercelRequest, res: VercelResponse) => {
         while (true) {
             try {
                 const cardSVG = await getProfileDetailsSVGWithThemeName(username, theme, token);
-                await sendAnalytics('profile-details-card', {username, theme}, req.headers);
                 res.setHeader('Content-Type', 'image/svg+xml');
                 res.setHeader('Cache-Control', CONST_CACHE_CONTROL);
                 res.send(cardSVG);
+                // Fire-and-forget: don't block the response on analytics
+                void sendAnalytics('profile_details_card', {username, theme}, req.headers);
                 return;
             } catch (err: any) {
                 console.log(err.message);

--- a/api/cards/repos-per-language.ts
+++ b/api/cards/repos-per-language.ts
@@ -33,10 +33,11 @@ export default async (req: VercelRequest, res: VercelResponse) => {
         while (true) {
             try {
                 const cardSVG = await getReposPerLanguageSVGWithThemeName(username, theme, excludeArr, token);
-                await sendAnalytics('repos-per-language-card', {username, theme}, req.headers);
                 res.setHeader('Content-Type', 'image/svg+xml');
                 res.setHeader('Cache-Control', CONST_CACHE_CONTROL);
                 res.send(cardSVG);
+                // Fire-and-forget: don't block the response on analytics
+                void sendAnalytics('repos_per_language_card', {username, theme}, req.headers);
                 return;
             } catch (err: any) {
                 console.log(err.message);

--- a/api/cards/stats.ts
+++ b/api/cards/stats.ts
@@ -21,10 +21,11 @@ export default async (req: VercelRequest, res: VercelResponse) => {
         while (true) {
             try {
                 const cardSVG = await getStatsSVGWithThemeName(username, theme, token);
-                await sendAnalytics('stats-card', {username, theme}, req.headers);
                 res.setHeader('Content-Type', 'image/svg+xml');
                 res.setHeader('Cache-Control', CONST_CACHE_CONTROL);
                 res.send(cardSVG);
+                // Fire-and-forget: don't block the response on analytics
+                void sendAnalytics('stats_card', {username, theme}, req.headers);
                 return;
             } catch (err: any) {
                 console.log(err.message);

--- a/src/app.ts
+++ b/src/app.ts
@@ -60,7 +60,7 @@ const action = async () => {
         try {
             core.info(`Creating ProfileDetailsCard...`);
             await createProfileDetailsCard(username, process.env.GITHUB_TOKEN!);
-            await sendAnalytics('action-profile-details-card', {username});
+            await sendAnalytics('action_profile_details_card', {username});
         } catch (error: any) {
             core.error(`Error when creating ProfileDetailsCard \n${error.stack}`);
         }

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -36,39 +36,41 @@ export async function sendAnalytics(
     // Only execute in Vercel environment with valid credentials
     if (!process.env.VERCEL || !GA_MEASUREMENT_ID || !GA_API_SECRET) return;
 
-    // Destructure to remove sensitive PII (username) from the final payload
-    const {username, ...cleanParams} = params;
-    const clientId = getClientId(username);
-
-    // Extract user IP and User-Agent from Vercel-injected headers
-    // Vercel headers are plain objects (string | string[] | undefined)
-    const forwardedFor = headers?.['x-forwarded-for'];
-    const ip = (Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor)?.split(',')[0] || '';
-
-    const userAgent = headers?.['user-agent'];
-    const ua = Array.isArray(userAgent) ? userAgent[0] : userAgent || '';
-
-    const url = `https://www.google-analytics.com/mp/collect?measurement_id=${GA_MEASUREMENT_ID}&api_secret=${GA_API_SECRET}`;
-
-    const payload = {
-        client_id: clientId,
-        // GA4 Measurement Protocol supports top-level overrides for UA and IP
-        user_agent: ua,
-        ip_override: ip,
-        events: [
-            {
-                name: eventName,
-                params: {
-                    ...cleanParams,
-                    // Use provided session_id or fallback to a timestamp-based ID to ensure session separation
-                    session_id: cleanParams.session_id || Date.now().toString(),
-                    engagement_time_msec: 100
-                }
-            }
-        ]
-    };
-
+    // Wrap the entire body so fire-and-forget callers (`void sendAnalytics(...)`)
+    // can never produce an unhandled rejection, even if setup throws before fetch.
     try {
+        // Destructure to remove sensitive PII (username) from the final payload
+        const {username, ...cleanParams} = params;
+        const clientId = getClientId(username);
+
+        // Extract user IP and User-Agent from Vercel-injected headers
+        // Vercel headers are plain objects (string | string[] | undefined)
+        const forwardedFor = headers?.['x-forwarded-for'];
+        const ip = (Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor)?.split(',')[0] || '';
+
+        const userAgent = headers?.['user-agent'];
+        const ua = Array.isArray(userAgent) ? userAgent[0] : userAgent || '';
+
+        const url = `https://www.google-analytics.com/mp/collect?measurement_id=${GA_MEASUREMENT_ID}&api_secret=${GA_API_SECRET}`;
+
+        const payload = {
+            client_id: clientId,
+            // GA4 Measurement Protocol supports top-level overrides for UA and IP
+            user_agent: ua,
+            ip_override: ip,
+            events: [
+                {
+                    name: eventName,
+                    params: {
+                        ...cleanParams,
+                        // Use provided session_id or fallback to a timestamp-based ID to ensure session separation
+                        session_id: cleanParams.session_id || Date.now().toString(),
+                        engagement_time_msec: 100
+                    }
+                }
+            ]
+        };
+
         const response = await fetch(url, {
             method: 'POST',
             body: JSON.stringify(payload),

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -84,6 +84,6 @@ export async function sendAnalytics(
         }
     } catch (e) {
         // Log error but do not throw to prevent breaking the main application flow
-        console.error('Analytics error (ignored):', e instanceof Error ? e.message : e);
+        console.error(`Analytics error (ignored) [${eventName}]:`, e instanceof Error ? e.message : e);
     }
 }


### PR DESCRIPTION
## Problem
GA4 dashboards were empty even though analytics is deployed. The GA4 Measurement Protocol **rejects event names containing hyphens** (`NAME_INVALID` — only alphanumerics and underscores allowed). Every event we sent (`stats-card`, `profile-details-card`, …) was **silently dropped** — `/mp/collect` returns `204` even for invalid payloads, so the error never surfaced.

## Fix
- Rename all event names to underscores: `stats_card`, `profile_details_card`, `most_commit_language_card`, `repos_per_language_card`, `productive_time_card`, `action_profile_details_card`.
- Move `sendAnalytics()` to **after** `res.send()` in the card handlers and fire-and-forget it, so the SVG response isn't blocked on the outbound analytics call.

## Verification
- All 6 new event names pass the GA4 **debug** endpoint (`/debug/mp/collect`) with empty `validationMessages`.
- `npm run build`, `npm run lint`, `npm test` (21 tests) all pass.

> Events still fire only on cache-miss (edge HITs don't invoke the function), so GA numbers are a lower bound — good for trends, not exact traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Card SVG responses are returned immediately, while analytics runs in the background (no longer blocking rendering).
  * Card endpoints now consistently set the correct `Content-Type` and `Cache-Control` headers alongside the SVG response.

* **Analytics**
  * Standardized analytics event names for cards and the profile details action.
  * Improved analytics reliability by capturing setup-related errors and ensuring failed analytics setup doesn’t delay responses.

* **Tracked Data**
  * Continued to send the same core tracking payload (e.g., `username`, `theme`, and `utcOffset` where applicable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->