### PR TITLE
fix: make pre-commit hook shebang portable for NixOS/devbox

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -8,7 +8,8 @@
     "shell": {
         "init_hook": [
             "echo 'Welcome to github-profile-summary-cards dev environment'",
-            "npm install"
+            "npm install",
+            "for f in .git/hooks/pre-commit node_modules/pre-commit/hook; do [ -f \"$f\" ] && sed '1s|#!/bin/bash|#!/usr/bin/env bash|' \"$f\" > \"$f.tmp\" && mv \"$f.tmp\" \"$f\" && chmod +x \"$f\"; done"
         ],
         "scripts": {
             "test": "npm test",


### PR DESCRIPTION
## Problem
The `pre-commit` npm package generates git hooks with a hard-coded `#!/bin/bash` shebang (both `.git/hooks/pre-commit` and its inner `node_modules/pre-commit/hook`). On systems without `/bin/bash` — e.g. **NixOS**, which only provides `/bin/sh` — every commit fails with:

```
.git/hooks/pre-commit: bad interpreter: /bin/bash: no such file or directory
```

## Fix
After `npm install`, the devbox `init_hook` now rewrites both shebangs to the portable `#!/usr/bin/env bash`. This runs on every devbox shell init, so it survives `npm install` regenerating the hooks. Harmless on systems that do have `/bin/bash`.

## Verification
- With the local hooks patched, a real `git commit` (no `--no-verify`) runs the pre-commit hook to completion: test + lint pass (21 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development environment setup by ensuring pre-commit hooks use a portable Bash interpreter.
  * Automatically restores executable permissions for detected pre-commit hooks after installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->