### PR TITLE
chore: remove ineffective cache-control header for /api/cards

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -17,15 +17,6 @@
     },
     "headers": [
         {
-            "source": "/api/cards/(.*)",
-            "headers": [
-                {
-                    "key": "cache-control",
-                    "value": "public, max-age=21600, s-maxage=21600, stale-while-revalidate=14400"
-                }
-            ]
-        },
-        {
             "source": "/api/theme",
             "headers": [
                 {


### PR DESCRIPTION
## What
Remove the `/api/cards/(.*)` `cache-control` header block from `vercel.json`.

## Why
The card handlers already set `Cache-Control` via `res.setHeader(CONST_CACHE_CONTROL)`, which overrides this vercel.json header. Verified in production: a successful card response returns the **code's** `max-age=14400`, not this block's `max-age=21600` — so the block is dead config for successful responses and only causes confusion about the real TTL.

Side benefit: transient **error cards** (the catch path doesn't set its own `Cache-Control`) were picking up this block's 6h cache. Removing it means a transient error is no longer edge-cached for hours.

The `/api/theme` CORS headers are untouched.

## Verification
- `vercel.json` remains valid JSON; `npm test` (21 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed caching headers from card API responses to ensure users receive up-to-date data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->