### PR TITLE
ci: use npm ci in test-and-lint to catch lockfile drift

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         node-version-file: '.node-version'
         cache: 'npm'
-    - run: npm install
+    - run: npm ci
     - run: npm run test
 
     - name: Analyze Test and/or Coverage Results
@@ -45,5 +45,5 @@ jobs:
       with:
         node-version-file: '.node-version'
         cache: 'npm'
-    - run: npm install
+    - run: npm ci
     - run: npm run lint


### PR DESCRIPTION
Switch both `test-and-lint` jobs from `npm install` to `npm ci` so lockfile drift fails at PR time instead of only surfacing in the release job's `npm ci` (which is how the recent release break slipped through). The lockfile is already in sync on `main` (via #259), so CI here should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated testing and linting setup for more consistent dependency installation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->