### PR TITLE
fix: cap repo queries at top-100 to prevent large-account timeouts

### DIFF
--- a/src/github-api/organization-details.ts
+++ b/src/github-api/organization-details.ts
@@ -36,7 +36,7 @@ const fetcher = (token: string, variables: any) => {
         },
         {
             query: `
-      query OrganizationDetails($login: String!, $endCursor: String) {
+      query OrganizationDetails($login: String!) {
         repositoryOwner(login: $login) {
             __typename
             ... on Organization {
@@ -50,12 +50,8 @@ const fetcher = (token: string, variables: any) => {
                 twitterUsername
                 createdAt
                 isVerified
-                repositories(first: 100, after: $endCursor, privacy: PUBLIC, isFork: false, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
+                repositories(first: 100, privacy: PUBLIC, isFork: false, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
                     totalCount
-                    pageInfo {
-                        endCursor
-                        hasNextPage
-                    }
                     nodes {
                         createdAt
                         forkCount
@@ -77,47 +73,37 @@ const fetcher = (token: string, variables: any) => {
 };
 
 export async function getOrganizationDetails(login: string, token: string): Promise<OrganizationDetails> {
-    let hasNextPage = true;
-    let cursor: string | null = null;
-    let organizationDetails: OrganizationDetails | null = null;
+    // Single top-100 (by stars) query instead of paginating every repo: unbounded
+    // pagination let large orgs exceed the Vercel timeout and burn the shared rate
+    // limit. totalPublicRepos stays accurate (via totalCount); the star/fork/issue
+    // sums reflect the top 100 repos, which is plenty for a summary card.
+    const res: any = await fetcher(token, {login: login});
 
-    while (hasNextPage) {
-        const res: any = await fetcher(token, {
-            login: login,
-            endCursor: cursor
-        });
-
-        if (res.data.errors) {
-            throw Error(res.data.errors[0].message || 'GetOrganizationDetails failed');
-        }
-
-        const owner = res.data.data.repositoryOwner;
-        if (!owner || owner.__typename !== 'Organization') {
-            throw Error(`Organization not found: ${login}`);
-        }
-        const org = owner;
-
-        if (organizationDetails === null) {
-            organizationDetails = new OrganizationDetails(org.id, org.login, org.name, org.createdAt);
-            organizationDetails.description = org.description;
-            organizationDetails.email = org.email || null;
-            organizationDetails.location = org.location;
-            organizationDetails.websiteUrl = org.websiteUrl;
-            organizationDetails.twitterUsername = org.twitterUsername;
-            organizationDetails.isVerified = !!org.isVerified;
-            organizationDetails.totalPublicRepos = org.repositories.totalCount;
-        }
-
-        for (const node of org.repositories.nodes) {
-            organizationDetails.totalStars += node.stargazers.totalCount;
-            organizationDetails.totalForks += node.forkCount;
-            organizationDetails.totalOpenIssues += node.issues.totalCount;
-            organizationDetails.repoCreatedAt.push(new Date(node.createdAt));
-        }
-
-        cursor = org.repositories.pageInfo.endCursor;
-        hasNextPage = org.repositories.pageInfo.hasNextPage;
+    if (res.data.errors) {
+        throw Error(res.data.errors[0].message || 'GetOrganizationDetails failed');
     }
 
-    return organizationDetails!;
+    const owner = res.data.data.repositoryOwner;
+    if (!owner || owner.__typename !== 'Organization') {
+        throw Error(`Organization not found: ${login}`);
+    }
+    const org = owner;
+
+    const organizationDetails = new OrganizationDetails(org.id, org.login, org.name, org.createdAt);
+    organizationDetails.description = org.description;
+    organizationDetails.email = org.email || null;
+    organizationDetails.location = org.location;
+    organizationDetails.websiteUrl = org.websiteUrl;
+    organizationDetails.twitterUsername = org.twitterUsername;
+    organizationDetails.isVerified = !!org.isVerified;
+    organizationDetails.totalPublicRepos = org.repositories.totalCount;
+
+    for (const node of org.repositories.nodes) {
+        organizationDetails.totalStars += node.stargazers.totalCount;
+        organizationDetails.totalForks += node.forkCount;
+        organizationDetails.totalOpenIssues += node.issues.totalCount;
+        organizationDetails.repoCreatedAt.push(new Date(node.createdAt));
+    }
+
+    return organizationDetails;
 }

--- a/src/github-api/organization-repos-per-language.ts
+++ b/src/github-api/organization-repos-per-language.ts
@@ -9,20 +9,16 @@ const fetcher = (token: string, variables: any) => {
         },
         {
             query: `
-      query OrganizationReposPerLanguage($login: String!, $endCursor: String) {
+      query OrganizationReposPerLanguage($login: String!) {
         repositoryOwner(login: $login) {
           __typename
           ... on Organization {
-            repositories(isFork: false, first: 100, after: $endCursor, privacy: PUBLIC, ownerAffiliations: OWNER) {
+            repositories(isFork: false, first: 100, privacy: PUBLIC, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
               nodes {
                 primaryLanguage {
                   name
                   color
                 }
-              }
-              pageInfo{
-                  endCursor
-                  hasNextPage
               }
             }
           }
@@ -40,31 +36,21 @@ export async function getOrganizationRepoLanguages(
     exclude: Array<string>,
     token: string
 ): Promise<RepoLanguages> {
-    let hasNextPage = true;
-    let cursor = null;
+    // Single top-100 (by stars) query instead of paginating every repo — see the
+    // note in the user repos-per-language module.
     const repoLanguages = new RepoLanguages();
-    const nodes = [];
 
-    while (hasNextPage) {
-        const res: any = await fetcher(token, {
-            login: login,
-            endCursor: cursor
-        });
-
-        if (res.data.errors) {
-            throw Error(res.data.errors[0].message || 'GetOrganizationRepoLanguage fail');
-        }
-        const owner = res.data.data.repositoryOwner;
-        if (!owner || owner.__typename !== 'Organization') {
-            throw Error(`Organization not found: ${login}`);
-        }
-        const org = owner;
-        cursor = org.repositories.pageInfo.endCursor;
-        hasNextPage = org.repositories.pageInfo.hasNextPage;
-        nodes.push(...org.repositories.nodes);
+    const res: any = await fetcher(token, {login: login});
+    if (res.data.errors) {
+        throw Error(res.data.errors[0].message || 'GetOrganizationRepoLanguage fail');
     }
+    const owner = res.data.data.repositoryOwner;
+    if (!owner || owner.__typename !== 'Organization') {
+        throw Error(`Organization not found: ${login}`);
+    }
+    const nodes = owner.repositories.nodes;
 
-    nodes.forEach(node => {
+    nodes.forEach((node: {primaryLanguage: {name: string; color: string} | null}) => {
         if (node.primaryLanguage) {
             const langName = node.primaryLanguage.name;
             const langColor = node.primaryLanguage.color;

--- a/src/github-api/repos-per-language.ts
+++ b/src/github-api/repos-per-language.ts
@@ -38,18 +38,14 @@ const fetcher = (token: string, variables: any) => {
         },
         {
             query: `
-      query ReposPerLanguage($login: String!,$endCursor: String) {
+      query ReposPerLanguage($login: String!) {
         user(login: $login) {
-          repositories(isFork: false, first: 100, after: $endCursor,ownerAffiliations: OWNER) {
+          repositories(isFork: false, first: 100, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
             nodes {
               primaryLanguage {
                 name
                 color
               }
-            }
-            pageInfo{
-                endCursor
-                hasNextPage
             }
           }
         }
@@ -66,26 +62,18 @@ export async function getRepoLanguages(
     exclude: Array<string>,
     token: string
 ): Promise<RepoLanguages> {
-    let hasNextPage = true;
-    let cursor = null;
+    // Cap at the top 100 repos (by stars) in a single query instead of paginating
+    // through every repo: unbounded pagination let large accounts blow past the
+    // Vercel function timeout and burn the shared GitHub rate limit for everyone.
     const repoLanguages = new RepoLanguages();
-    const nodes = [];
 
-    while (hasNextPage) {
-        const res: any = await fetcher(token, {
-            login: username,
-            endCursor: cursor
-        });
-
-        if (res.data.errors) {
-            throw Error(res.data.errors[0].message || 'GetRepoLanguage fail');
-        }
-        cursor = res.data.data.user.repositories.pageInfo.endCursor;
-        hasNextPage = res.data.data.user.repositories.pageInfo.hasNextPage;
-        nodes.push(...res.data.data.user.repositories.nodes);
+    const res: any = await fetcher(token, {login: username});
+    if (res.data.errors) {
+        throw Error(res.data.errors[0].message || 'GetRepoLanguage fail');
     }
+    const nodes = res.data.data.user.repositories.nodes;
 
-    nodes.forEach(node => {
+    nodes.forEach((node: {primaryLanguage: {name: string; color: string} | null}) => {
         if (node.primaryLanguage) {
             const langName = node.primaryLanguage.name;
             const langColor = node.primaryLanguage.color;

--- a/tests/github-api/organization-details.test.ts
+++ b/tests/github-api/organization-details.test.ts
@@ -19,10 +19,6 @@ const firstPage = {
             isVerified: true,
             repositories: {
                 totalCount: 3,
-                pageInfo: {
-                    endCursor: 'CURSOR1',
-                    hasNextPage: true
-                },
                 nodes: [
                     {
                         createdAt: '2020-01-01T00:00:00Z',
@@ -35,34 +31,7 @@ const firstPage = {
                         forkCount: 2,
                         stargazers: {totalCount: 50},
                         issues: {totalCount: 1}
-                    }
-                ]
-            }
-        }
-    }
-};
-
-const lastPage = {
-    data: {
-        repositoryOwner: {
-            __typename: 'Organization',
-            id: 'orgID',
-            login: 'acme',
-            name: 'Acme Corp',
-            description: 'A test organization',
-            email: 'contact@acme.example',
-            location: 'Internet',
-            websiteUrl: 'https://acme.example',
-            twitterUsername: 'acme',
-            createdAt: '2015-01-01T00:00:00Z',
-            isVerified: true,
-            repositories: {
-                totalCount: 3,
-                pageInfo: {
-                    endCursor: null,
-                    hasNextPage: false
-                },
-                nodes: [
+                    },
                     {
                         createdAt: '2022-06-30T00:00:00Z',
                         forkCount: 1,
@@ -97,12 +66,8 @@ afterEach(() => {
 });
 
 describe('github api for organization details', () => {
-    it('should aggregate repo data across paginated responses', async () => {
-        mock.onPost('https://api.github.com/graphql')
-            .replyOnce(200, firstPage)
-            .onPost('https://api.github.com/graphql')
-            .replyOnce(200, lastPage)
-            .onAny();
+    it('should aggregate repo data from the top-100 query', async () => {
+        mock.onPost('https://api.github.com/graphql').reply(200, firstPage);
         const orgDetails = await getOrganizationDetails('acme', 'token');
         expect(orgDetails).toEqual({
             id: 'orgID',

--- a/tests/github-api/organization-repos-per-language.test.ts
+++ b/tests/github-api/organization-repos-per-language.test.ts
@@ -9,23 +9,11 @@ const firstData = {
             __typename: 'Organization',
             repositories: {
                 nodes: [
-                    {
-                        primaryLanguage: {
-                            color: '#b07219',
-                            name: 'Java'
-                        }
-                    },
-                    {
-                        primaryLanguage: {
-                            color: '#dea584',
-                            name: 'Rust'
-                        }
-                    }
-                ],
-                pageInfo: {
-                    endCursor: 'ABCD29yOnYyOpHOBslODA==',
-                    hasNextPage: true
-                }
+                    {primaryLanguage: {color: '#b07219', name: 'Java'}},
+                    {primaryLanguage: {color: '#dea584', name: 'Rust'}},
+                    {primaryLanguage: {color: '#b07219', name: 'Java'}},
+                    {primaryLanguage: {color: '#f18e33', name: 'Kotlin'}}
+                ]
             }
         }
     }
@@ -82,11 +70,7 @@ afterEach(() => {
 
 describe('organization repos per language on github', () => {
     it('should get correct data', async () => {
-        mock.onPost('https://api.github.com/graphql')
-            .replyOnce(200, firstData)
-            .onPost('https://api.github.com/graphql')
-            .replyOnce(200, lastData)
-            .onAny();
+        mock.onPost('https://api.github.com/graphql').reply(200, firstData);
         const repoData = await getOrganizationRepoLanguages('acme', [], 'token');
         expect(repoData).toEqual({
             languageMap: new Map([

--- a/tests/github-api/repos-per-language.test.ts
+++ b/tests/github-api/repos-per-language.test.ts
@@ -3,54 +3,16 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 const mock = new MockAdapter(axios);
 
-const firstData = {
+const singlePageData = {
     data: {
         user: {
             repositories: {
                 nodes: [
-                    {
-                        primaryLanguage: {
-                            color: '#b07219',
-                            name: 'Java'
-                        }
-                    },
-                    {
-                        primaryLanguage: {
-                            color: '#dea584',
-                            name: 'Rust'
-                        }
-                    }
-                ],
-                pageInfo: {
-                    endCursor: 'ABCD29yOnYyOpHOBslODA==',
-                    hasNextPage: true
-                }
-            }
-        }
-    }
-};
-const lastData = {
-    data: {
-        user: {
-            repositories: {
-                nodes: [
-                    {
-                        primaryLanguage: {
-                            color: '#b07219',
-                            name: 'Java'
-                        }
-                    },
-                    {
-                        primaryLanguage: {
-                            color: '#f18e33',
-                            name: 'Kotlin'
-                        }
-                    }
-                ],
-                pageInfo: {
-                    endCursor: null,
-                    hasNextPage: false
-                }
+                    {primaryLanguage: {color: '#b07219', name: 'Java'}},
+                    {primaryLanguage: {color: '#dea584', name: 'Rust'}},
+                    {primaryLanguage: {color: '#b07219', name: 'Java'}},
+                    {primaryLanguage: {color: '#f18e33', name: 'Kotlin'}}
+                ]
             }
         }
     }
@@ -112,11 +74,7 @@ afterEach(() => {
 
 describe('repos per language on github', () => {
     it('should get correct data', async () => {
-        mock.onPost('https://api.github.com/graphql')
-            .replyOnce(200, firstData)
-            .onPost('https://api.github.com/graphql')
-            .replyOnce(200, lastData)
-            .onAny();
+        mock.onPost('https://api.github.com/graphql').reply(200, singlePageData);
         const repoData = await getRepoLanguages('vn7n24fzkq', [], 'token');
         expect(repoData).toEqual({
             languageMap: new Map([


### PR DESCRIPTION
## Problem
Three GitHub-API modules paginated through **all** of an account's repos (unbounded `while (hasNextPage)`): user `repos-per-language`, org `repos-per-language`, and org `details`. For large accounts this exceeded the Vercel 10s function timeout — observed live: the `vercel` org card returned **504 FUNCTION_INVOCATION_TIMEOUT**.

Because every attempt still consumes GitHub GraphQL points from the **shared** rate-limit bucket that all card requests draw from, a large account being requested repeatedly (never caching a success) can degrade service for **all** users, and is a mild abuse vector on a public endpoint.

## Fix
Single `first: 100` query ordered by stars, no pagination. Repo counts stay accurate (`totalCount`); star/fork/issue sums and the language mix reflect the top-100 repos — enough for a summary card. `commits-per-language` (100/50) and `productive-time` were already capped.

## Verification
- build + lint + tests pass (22 suites / 79 tests; pagination tests updated to single-page).
- Local render of the previously-timing-out `vercel` org now succeeds well under the 10s budget; `denoland` too.

Deploys with the next release (v0.8.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Repository statistics and language data now load from a single top-100 repository result, reducing repeated data requests.

* **Bug Fixes**
  * Improved handling of organization validation and API errors when retrieving repository information.

* **Tests**
  * Updated coverage to verify results from the streamlined top-100 repository data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->