### PR TITLE
fix: cap repo pagination only on Vercel, paginate fully in the Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ The same URLs return organization-flavored cards when the login resolves to an o
 
 The same GitHub Action setup also works for organizations — set `USERNAME` to the org login. The generated `profile-summary-card-output/` will contain 4 cards per theme instead of 5.
 
+> **Hosted API vs GitHub Action.** On the hosted API (`*.vercel.app`), the language and stats cards aggregate your **top 100 repositories by stars** — this keeps each request within the serverless time limit and light on the shared rate limit. The **GitHub Action** runs with your own token and no time limit, so it includes **all** of your repositories. (The total-repo count is exact either way.)
+
 ---
 
 ## Setting up your GitHub token

--- a/docs/README_zh-tw.md
+++ b/docs/README_zh-tw.md
@@ -50,6 +50,8 @@
 
 組織模式下,`profile-summary-card-output/` 每個主題會產生 4 張卡片(沒有 productive-time)。
 
+> **Hosted API 與 GitHub Action 的差異。** 在 hosted API(`*.vercel.app`)上,語言與 stats 卡片會彙整你**依 star 排序的前 100 個 repo** —— 這是為了讓每次請求不超過 serverless 時間限制、也減輕共用額度的負擔。**GitHub Action** 用你自己的 token、沒有時間限制,所以會涵蓋**全部** repo。(repo 總數兩種方式都是準確的。)
+
 ---
 
 ## 設定 GitHub Token

--- a/src/github-api/organization-details.ts
+++ b/src/github-api/organization-details.ts
@@ -36,7 +36,7 @@ const fetcher = (token: string, variables: any) => {
         },
         {
             query: `
-      query OrganizationDetails($login: String!) {
+      query OrganizationDetails($login: String!, $endCursor: String) {
         repositoryOwner(login: $login) {
             __typename
             ... on Organization {
@@ -50,8 +50,12 @@ const fetcher = (token: string, variables: any) => {
                 twitterUsername
                 createdAt
                 isVerified
-                repositories(first: 100, privacy: PUBLIC, isFork: false, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
+                repositories(first: 100, after: $endCursor, privacy: PUBLIC, isFork: false, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
                     totalCount
+                    pageInfo {
+                        endCursor
+                        hasNextPage
+                    }
                     nodes {
                         createdAt
                         forkCount
@@ -73,37 +77,47 @@ const fetcher = (token: string, variables: any) => {
 };
 
 export async function getOrganizationDetails(login: string, token: string): Promise<OrganizationDetails> {
-    // Single top-100 (by stars) query instead of paginating every repo: unbounded
-    // pagination let large orgs exceed the Vercel timeout and burn the shared rate
-    // limit. totalPublicRepos stays accurate (via totalCount); the star/fork/issue
-    // sums reflect the top 100 repos, which is plenty for a summary card.
-    const res: any = await fetcher(token, {login: login});
+    // On Vercel (shared token + 10s timeout) fetch only the top 100 repos by stars
+    // in one query. Run as a GitHub Action / CLI (own token, no timeout) paginate
+    // every repo for accurate totals. totalPublicRepos is always exact (totalCount).
+    let organizationDetails: OrganizationDetails | null = null;
+    let cursor: string | null = null;
+    let hasNextPage = true;
 
-    if (res.data.errors) {
-        throw Error(res.data.errors[0].message || 'GetOrganizationDetails failed');
+    while (hasNextPage) {
+        const res: any = await fetcher(token, {login: login, endCursor: cursor});
+
+        if (res.data.errors) {
+            throw Error(res.data.errors[0].message || 'GetOrganizationDetails failed');
+        }
+
+        const owner = res.data.data.repositoryOwner;
+        if (!owner || owner.__typename !== 'Organization') {
+            throw Error(`Organization not found: ${login}`);
+        }
+        const org = owner;
+
+        if (organizationDetails === null) {
+            organizationDetails = new OrganizationDetails(org.id, org.login, org.name, org.createdAt);
+            organizationDetails.description = org.description;
+            organizationDetails.email = org.email || null;
+            organizationDetails.location = org.location;
+            organizationDetails.websiteUrl = org.websiteUrl;
+            organizationDetails.twitterUsername = org.twitterUsername;
+            organizationDetails.isVerified = !!org.isVerified;
+            organizationDetails.totalPublicRepos = org.repositories.totalCount;
+        }
+
+        for (const node of org.repositories.nodes) {
+            organizationDetails.totalStars += node.stargazers.totalCount;
+            organizationDetails.totalForks += node.forkCount;
+            organizationDetails.totalOpenIssues += node.issues.totalCount;
+            organizationDetails.repoCreatedAt.push(new Date(node.createdAt));
+        }
+
+        cursor = org.repositories.pageInfo?.endCursor ?? null;
+        hasNextPage = !process.env.VERCEL && !!org.repositories.pageInfo?.hasNextPage;
     }
 
-    const owner = res.data.data.repositoryOwner;
-    if (!owner || owner.__typename !== 'Organization') {
-        throw Error(`Organization not found: ${login}`);
-    }
-    const org = owner;
-
-    const organizationDetails = new OrganizationDetails(org.id, org.login, org.name, org.createdAt);
-    organizationDetails.description = org.description;
-    organizationDetails.email = org.email || null;
-    organizationDetails.location = org.location;
-    organizationDetails.websiteUrl = org.websiteUrl;
-    organizationDetails.twitterUsername = org.twitterUsername;
-    organizationDetails.isVerified = !!org.isVerified;
-    organizationDetails.totalPublicRepos = org.repositories.totalCount;
-
-    for (const node of org.repositories.nodes) {
-        organizationDetails.totalStars += node.stargazers.totalCount;
-        organizationDetails.totalForks += node.forkCount;
-        organizationDetails.totalOpenIssues += node.issues.totalCount;
-        organizationDetails.repoCreatedAt.push(new Date(node.createdAt));
-    }
-
-    return organizationDetails;
+    return organizationDetails!;
 }

--- a/src/github-api/organization-repos-per-language.ts
+++ b/src/github-api/organization-repos-per-language.ts
@@ -9,16 +9,20 @@ const fetcher = (token: string, variables: any) => {
         },
         {
             query: `
-      query OrganizationReposPerLanguage($login: String!) {
+      query OrganizationReposPerLanguage($login: String!, $endCursor: String) {
         repositoryOwner(login: $login) {
           __typename
           ... on Organization {
-            repositories(isFork: false, first: 100, privacy: PUBLIC, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
+            repositories(isFork: false, first: 100, after: $endCursor, privacy: PUBLIC, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
               nodes {
                 primaryLanguage {
                   name
                   color
                 }
+              }
+              pageInfo {
+                endCursor
+                hasNextPage
               }
             }
           }
@@ -36,19 +40,26 @@ export async function getOrganizationRepoLanguages(
     exclude: Array<string>,
     token: string
 ): Promise<RepoLanguages> {
-    // Single top-100 (by stars) query instead of paginating every repo — see the
+    // Vercel: top-100 by stars in one query. Action/CLI: paginate all. See the
     // note in the user repos-per-language module.
     const repoLanguages = new RepoLanguages();
+    const nodes: {primaryLanguage: {name: string; color: string} | null}[] = [];
+    let cursor: string | null = null;
+    let hasNextPage = true;
 
-    const res: any = await fetcher(token, {login: login});
-    if (res.data.errors) {
-        throw Error(res.data.errors[0].message || 'GetOrganizationRepoLanguage fail');
+    while (hasNextPage) {
+        const res: any = await fetcher(token, {login: login, endCursor: cursor});
+        if (res.data.errors) {
+            throw Error(res.data.errors[0].message || 'GetOrganizationRepoLanguage fail');
+        }
+        const owner = res.data.data.repositoryOwner;
+        if (!owner || owner.__typename !== 'Organization') {
+            throw Error(`Organization not found: ${login}`);
+        }
+        nodes.push(...owner.repositories.nodes);
+        cursor = owner.repositories.pageInfo?.endCursor ?? null;
+        hasNextPage = !process.env.VERCEL && !!owner.repositories.pageInfo?.hasNextPage;
     }
-    const owner = res.data.data.repositoryOwner;
-    if (!owner || owner.__typename !== 'Organization') {
-        throw Error(`Organization not found: ${login}`);
-    }
-    const nodes = owner.repositories.nodes;
 
     nodes.forEach((node: {primaryLanguage: {name: string; color: string} | null}) => {
         if (node.primaryLanguage) {

--- a/src/github-api/repos-per-language.ts
+++ b/src/github-api/repos-per-language.ts
@@ -38,14 +38,18 @@ const fetcher = (token: string, variables: any) => {
         },
         {
             query: `
-      query ReposPerLanguage($login: String!) {
+      query ReposPerLanguage($login: String!, $endCursor: String) {
         user(login: $login) {
-          repositories(isFork: false, first: 100, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
+          repositories(isFork: false, first: 100, after: $endCursor, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
             nodes {
               primaryLanguage {
                 name
                 color
               }
+            }
+            pageInfo {
+              endCursor
+              hasNextPage
             }
           }
         }
@@ -62,16 +66,24 @@ export async function getRepoLanguages(
     exclude: Array<string>,
     token: string
 ): Promise<RepoLanguages> {
-    // Cap at the top 100 repos (by stars) in a single query instead of paginating
-    // through every repo: unbounded pagination let large accounts blow past the
-    // Vercel function timeout and burn the shared GitHub rate limit for everyone.
+    // On Vercel (shared token + 10s function timeout) take only the top 100 repos
+    // by stars in a single query. Run as a GitHub Action / CLI (the user's own
+    // token, no timeout) paginate through every repo for a complete count.
     const repoLanguages = new RepoLanguages();
+    const nodes: {primaryLanguage: {name: string; color: string} | null}[] = [];
+    let cursor: string | null = null;
+    let hasNextPage = true;
 
-    const res: any = await fetcher(token, {login: username});
-    if (res.data.errors) {
-        throw Error(res.data.errors[0].message || 'GetRepoLanguage fail');
+    while (hasNextPage) {
+        const res: any = await fetcher(token, {login: username, endCursor: cursor});
+        if (res.data.errors) {
+            throw Error(res.data.errors[0].message || 'GetRepoLanguage fail');
+        }
+        const repos = res.data.data.user.repositories;
+        nodes.push(...repos.nodes);
+        cursor = repos.pageInfo?.endCursor ?? null;
+        hasNextPage = !process.env.VERCEL && !!repos.pageInfo?.hasNextPage;
     }
-    const nodes = res.data.data.user.repositories.nodes;
 
     nodes.forEach((node: {primaryLanguage: {name: string; color: string} | null}) => {
         if (node.primaryLanguage) {

--- a/tests/github-api/repos-per-language.test.ts
+++ b/tests/github-api/repos-per-language.test.ts
@@ -18,6 +18,30 @@ const singlePageData = {
     }
 };
 
+const page1 = {
+    data: {
+        user: {
+            repositories: {
+                nodes: [
+                    {primaryLanguage: {color: '#b07219', name: 'Java'}},
+                    {primaryLanguage: {color: '#dea584', name: 'Rust'}}
+                ],
+                pageInfo: {endCursor: 'C1', hasNextPage: true}
+            }
+        }
+    }
+};
+const page2 = {
+    data: {
+        user: {
+            repositories: {
+                nodes: [{primaryLanguage: {color: '#f18e33', name: 'Kotlin'}}],
+                pageInfo: {endCursor: null, hasNextPage: false}
+            }
+        }
+    }
+};
+
 const error = {
     errors: [
         {
@@ -70,6 +94,7 @@ const dataContainingLanguageWithWhiteSpace = {
 
 afterEach(() => {
     mock.reset();
+    delete process.env.VERCEL;
 });
 
 describe('repos per language on github', () => {
@@ -99,5 +124,30 @@ describe('repos per language on github', () => {
                 ['Java', {color: '#f9e79f', count: 1, name: 'Java'}]
             ])
         });
+    });
+
+    it('paginates through every page when not on Vercel (Action/CLI)', async () => {
+        delete process.env.VERCEL;
+        mock.onPost('https://api.github.com/graphql')
+            .replyOnce(200, page1)
+            .onPost('https://api.github.com/graphql')
+            .replyOnce(200, page2)
+            .onAny();
+        const repoData = await getRepoLanguages('vn7n24fzkq', [], 'token');
+        // second page's Kotlin is included → pagination happened
+        expect(repoData.getLanguageMap().has('Kotlin')).toBe(true);
+    });
+
+    it('stops after the first page on Vercel', async () => {
+        process.env.VERCEL = '1';
+        mock.onPost('https://api.github.com/graphql')
+            .replyOnce(200, page1)
+            .onPost('https://api.github.com/graphql')
+            .replyOnce(200, page2)
+            .onAny();
+        const repoData = await getRepoLanguages('vn7n24fzkq', [], 'token');
+        // only page 1 fetched → Kotlin (page 2) absent
+        expect(repoData.getLanguageMap().has('Kotlin')).toBe(false);
+        expect(repoData.getLanguageMap().has('Java')).toBe(true);
     });
 });


### PR DESCRIPTION
## Why
The top-100 cap in #261 is the right protection for the **Vercel API** (shared server token, 10s function timeout, all users draw from one rate-limit bucket). But those github-api modules are shared with the **GitHub Action**, which runs in the user's *own* workflow with their *own* token and no timeout — there, capping to 100 repos needlessly makes the committed cards less accurate for users with many repos.

## What
Gate pagination on `process.env.VERCEL` — the same pattern `stats-card.ts` already uses (it limits contributions to 1 year on Vercel):
- **On Vercel**: single `first: 100` query ordered by stars (timeout + shared-quota safe).
- **As an Action / CLI**: paginate through every repo for a complete count.

Applies to `repos-per-language` (user), `organization-repos-per-language`, and `organization-details`. `totalPublicRepos` stays exact either way.

## Verification
- build + lint + tests pass (22 suites / **81** tests — added coverage asserting Vercel stops at page 1 and Action paginates all).

Deploys with the next release (v0.8.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub Action reports now include repository language and statistics from all repositories.
  * Hosted API reports continue using the top 100 repositories by stars for these cards.
  * Repository totals remain accurate in both environments.
* **Documentation**
  * Added English and Traditional Chinese guidance explaining the differences between hosted API and GitHub Action results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->