### PR TITLE
refactor: shared card handler + logic/rate-limit fixes

### DIFF
--- a/api/cards/most-commit-language.ts
+++ b/api/cards/most-commit-language.ts
@@ -1,61 +1,16 @@
 import {dispatchMostCommitLanguageSVG} from '../../src/utils/owner-dispatch';
-import {getGitHubToken} from '../utils/github-token-updater';
-import {getErrorMsgCard} from '../utils/error-card';
-import {sendAnalytics} from '../../src/utils/analytics';
-import {CONST_CACHE_CONTROL} from '../../src/const/cache';
-import {resolveThemeName, parseThemeColorOverride} from '../../src/const/theme';
+import {handleCard} from '../utils/handle-card';
 import {translateLanguage} from '../../src/utils/translator';
 import type {VercelRequest, VercelResponse} from '@vercel/node';
 
-export default async (req: VercelRequest, res: VercelResponse) => {
-    const {username, theme: rawTheme = 'default', exclude = ''} = req.query;
-
-    if (typeof rawTheme !== 'string') {
-        res.status(400).send('theme must be a string');
-        return;
-    }
-    if (typeof username !== 'string') {
-        res.status(400).send('username must be a string');
-        return;
-    }
+export default (req: VercelRequest, res: VercelResponse) => {
+    const {exclude = ''} = req.query;
     if (typeof exclude !== 'string') {
         res.status(400).send('exclude must be a string');
         return;
     }
-    const theme = resolveThemeName(rawTheme);
-    const override = parseThemeColorOverride(req.query);
-    const excludeArr = <string[]>[];
-    exclude.split(',').forEach(function (val) {
-        const translatedLanguage = translateLanguage(val);
-        excludeArr.push(translatedLanguage.toLowerCase());
-    });
-
-    try {
-        let token = getGitHubToken(0);
-        let tokenIndex = 0;
-        while (true) {
-            try {
-                const cardSVG = await dispatchMostCommitLanguageSVG(username, theme, excludeArr, token, override);
-                res.setHeader('Content-Type', 'image/svg+xml');
-                res.setHeader('Cache-Control', CONST_CACHE_CONTROL);
-                res.send(cardSVG);
-                // Fire-and-forget: don't block the response on analytics
-                void sendAnalytics('most_commit_language_card', {username, theme}, req.headers);
-                return;
-            } catch (err: any) {
-                console.log(err.message);
-                // We update github token and try again, until getNextGitHubToken throw an Error
-                if (err.response && (err.response.status === 403 || err.response.status === 401)) {
-                    tokenIndex += 1;
-                    token = getGitHubToken(tokenIndex);
-                } else {
-                    throw err;
-                }
-            }
-        }
-    } catch (err: any) {
-        console.log(err);
-        res.setHeader('Content-Type', 'image/svg+xml');
-        res.send(getErrorMsgCard(err.message, theme));
-    }
+    const excludeArr = exclude.split(',').map(val => translateLanguage(val).toLowerCase());
+    return handleCard(req, res, 'most_commit_language_card', (username, theme, override, token) =>
+        dispatchMostCommitLanguageSVG(username, theme, excludeArr, token, override)
+    );
 };

--- a/api/cards/productive-time.ts
+++ b/api/cards/productive-time.ts
@@ -1,72 +1,34 @@
 import {getProductiveTimeSVGWithThemeName} from '../../src/cards/productive-time-card';
 import {getOwnerType} from '../../src/github-api/owner-type';
-import {getGitHubToken} from '../utils/github-token-updater';
 import {getErrorMsgCard} from '../utils/error-card';
-import {sendAnalytics} from '../../src/utils/analytics';
-import {CONST_CACHE_CONTROL} from '../../src/const/cache';
-import {resolveThemeName, parseThemeColorOverride} from '../../src/const/theme';
+import {handleCard} from '../utils/handle-card';
 import type {VercelRequest, VercelResponse} from '@vercel/node';
 
-export default async (req: VercelRequest, res: VercelResponse) => {
-    const {username, theme: rawTheme = 'default', utcOffset = '0'} = req.query;
-    if (typeof rawTheme !== 'string') {
-        res.status(400).send('theme must be a string');
-        return;
-    }
-    if (typeof username !== 'string') {
-        res.status(400).send('username must be a string');
-        return;
-    }
-    if (typeof utcOffset !== 'string') {
+const ORG_NOT_SUPPORTED =
+    'The Productive Time card is not available for organization accounts. This card relies on per-user contribution data that GitHub does not expose at the organization level.';
+
+export default (req: VercelRequest, res: VercelResponse) => {
+    const {utcOffset: rawOffset = '0'} = req.query;
+    if (typeof rawOffset !== 'string') {
         res.status(400).send('utcOffset must be a string');
         return;
     }
-    const theme = resolveThemeName(rawTheme);
-    const override = parseThemeColorOverride(req.query);
-    try {
-        let token = getGitHubToken(0);
-        let tokenIndex = 0;
-        while (true) {
-            try {
-                const ownerType = await getOwnerType(username, token);
-                if (ownerType === 'Organization') {
-                    res.setHeader('Content-Type', 'image/svg+xml');
-                    res.setHeader('Cache-Control', CONST_CACHE_CONTROL);
-                    res.send(
-                        getErrorMsgCard(
-                            'The Productive Time card is not available for organization accounts. This card relies on per-user contribution data that GitHub does not expose at the organization level.',
-                            theme
-                        )
-                    );
-                    return;
-                }
-                const cardSVG = await getProductiveTimeSVGWithThemeName(
-                    username,
-                    theme,
-                    Number(utcOffset),
-                    token,
-                    override
-                );
-                res.setHeader('Content-Type', 'image/svg+xml');
-                res.setHeader('Cache-Control', CONST_CACHE_CONTROL);
-                res.send(cardSVG);
-                // Fire-and-forget: don't block the response on analytics
-                void sendAnalytics('productive_time_card', {username, theme, utcOffset}, req.headers);
-                return;
-            } catch (err: any) {
-                console.log(err.message);
-                // We update github token and try again, until getNextGitHubToken throw an Error
-                if (err.response && (err.response.status === 403 || err.response.status === 401)) {
-                    tokenIndex += 1;
-                    token = getGitHubToken(tokenIndex);
-                } else {
-                    throw err;
-                }
+    // Validate + clamp to a real UTC offset range so a non-numeric value can't
+    // produce an all-zero chart (NaN index) and a huge value can't grow the
+    // 24-hour bucket array out of range (which throws in the template).
+    const parsed = Number(rawOffset);
+    const utcOffset = Number.isFinite(parsed) ? Math.min(14, Math.max(-12, parsed)) : 0;
+    return handleCard(
+        req,
+        res,
+        'productive_time_card',
+        async (username, theme, override, token) => {
+            const ownerType = await getOwnerType(username, token);
+            if (ownerType === 'Organization') {
+                return getErrorMsgCard(ORG_NOT_SUPPORTED, theme);
             }
-        }
-    } catch (err: any) {
-        console.log(err);
-        res.setHeader('Content-Type', 'image/svg+xml');
-        res.send(getErrorMsgCard(err.message, theme));
-    }
+            return getProductiveTimeSVGWithThemeName(username, theme, utcOffset, token, override);
+        },
+        {utcOffset: String(utcOffset)}
+    );
 };

--- a/api/cards/profile-details.ts
+++ b/api/cards/profile-details.ts
@@ -1,49 +1,8 @@
 import {dispatchProfileDetailsSVG} from '../../src/utils/owner-dispatch';
-import {getGitHubToken} from '../utils/github-token-updater';
-import {getErrorMsgCard} from '../utils/error-card';
-import {sendAnalytics} from '../../src/utils/analytics';
-import {CONST_CACHE_CONTROL} from '../../src/const/cache';
-import {resolveThemeName, parseThemeColorOverride} from '../../src/const/theme';
+import {handleCard} from '../utils/handle-card';
 import type {VercelRequest, VercelResponse} from '@vercel/node';
 
-export default async (req: VercelRequest, res: VercelResponse) => {
-    const {username, theme: rawTheme = 'default'} = req.query;
-    if (typeof rawTheme !== 'string') {
-        res.status(400).send('theme must be a string');
-        return;
-    }
-    if (typeof username !== 'string') {
-        res.status(400).send('username must be a string');
-        return;
-    }
-    const theme = resolveThemeName(rawTheme);
-    const override = parseThemeColorOverride(req.query);
-    try {
-        let token = getGitHubToken(0);
-        let tokenIndex = 0;
-        while (true) {
-            try {
-                const cardSVG = await dispatchProfileDetailsSVG(username, theme, token, override);
-                res.setHeader('Content-Type', 'image/svg+xml');
-                res.setHeader('Cache-Control', CONST_CACHE_CONTROL);
-                res.send(cardSVG);
-                // Fire-and-forget: don't block the response on analytics
-                void sendAnalytics('profile_details_card', {username, theme}, req.headers);
-                return;
-            } catch (err: any) {
-                console.log(err.message);
-                // We update github token and try again, until getNextGitHubToken throw an Error
-                if (err.response && (err.response.status === 403 || err.response.status === 401)) {
-                    tokenIndex += 1;
-                    token = getGitHubToken(tokenIndex);
-                } else {
-                    throw err;
-                }
-            }
-        }
-    } catch (err: any) {
-        console.log(err);
-        res.setHeader('Content-Type', 'image/svg+xml');
-        res.send(getErrorMsgCard(err.message, theme));
-    }
-};
+export default (req: VercelRequest, res: VercelResponse) =>
+    handleCard(req, res, 'profile_details_card', (username, theme, override, token) =>
+        dispatchProfileDetailsSVG(username, theme, token, override)
+    );

--- a/api/cards/repos-per-language.ts
+++ b/api/cards/repos-per-language.ts
@@ -1,60 +1,16 @@
 import {dispatchReposPerLanguageSVG} from '../../src/utils/owner-dispatch';
-import {getGitHubToken} from '../utils/github-token-updater';
-import {getErrorMsgCard} from '../utils/error-card';
-import {sendAnalytics} from '../../src/utils/analytics';
-import {CONST_CACHE_CONTROL} from '../../src/const/cache';
-import {resolveThemeName, parseThemeColorOverride} from '../../src/const/theme';
+import {handleCard} from '../utils/handle-card';
 import {translateLanguage} from '../../src/utils/translator';
 import type {VercelRequest, VercelResponse} from '@vercel/node';
 
-export default async (req: VercelRequest, res: VercelResponse) => {
-    const {username, theme: rawTheme = 'default', exclude = ''} = req.query;
-
-    if (typeof rawTheme !== 'string') {
-        res.status(400).send('theme must be a string');
-        return;
-    }
-    if (typeof username !== 'string') {
-        res.status(400).send('username must be a string');
-        return;
-    }
+export default (req: VercelRequest, res: VercelResponse) => {
+    const {exclude = ''} = req.query;
     if (typeof exclude !== 'string') {
         res.status(400).send('exclude must be a string');
         return;
     }
-    const theme = resolveThemeName(rawTheme);
-    const override = parseThemeColorOverride(req.query);
-    const excludeArr = <string[]>[];
-    exclude.split(',').forEach(function (val) {
-        const translatedLanguage = translateLanguage(val);
-        excludeArr.push(translatedLanguage.toLowerCase());
-    });
-
-    try {
-        let token = getGitHubToken(0);
-        let tokenIndex = 0;
-        while (true) {
-            try {
-                const cardSVG = await dispatchReposPerLanguageSVG(username, theme, excludeArr, token, override);
-                res.setHeader('Content-Type', 'image/svg+xml');
-                res.setHeader('Cache-Control', CONST_CACHE_CONTROL);
-                res.send(cardSVG);
-                // Fire-and-forget: don't block the response on analytics
-                void sendAnalytics('repos_per_language_card', {username, theme}, req.headers);
-                return;
-            } catch (err: any) {
-                console.log(err.message);
-                // We update github token and try again, until getNextGitHubToken throw an Error
-                if (err.response && (err.response.status === 403 || err.response.status === 401)) {
-                    tokenIndex += 1;
-                    token = getGitHubToken(tokenIndex);
-                } else {
-                    throw err;
-                }
-            }
-        }
-    } catch (err: any) {
-        res.setHeader('Content-Type', 'image/svg+xml');
-        res.send(getErrorMsgCard(err.message, theme));
-    }
+    const excludeArr = exclude.split(',').map(val => translateLanguage(val).toLowerCase());
+    return handleCard(req, res, 'repos_per_language_card', (username, theme, override, token) =>
+        dispatchReposPerLanguageSVG(username, theme, excludeArr, token, override)
+    );
 };

--- a/api/cards/stats.ts
+++ b/api/cards/stats.ts
@@ -1,49 +1,8 @@
 import {dispatchStatsSVG} from '../../src/utils/owner-dispatch';
-import {getGitHubToken} from '../utils/github-token-updater';
-import {getErrorMsgCard} from '../utils/error-card';
-import {sendAnalytics} from '../../src/utils/analytics';
-import {CONST_CACHE_CONTROL} from '../../src/const/cache';
-import {resolveThemeName, parseThemeColorOverride} from '../../src/const/theme';
+import {handleCard} from '../utils/handle-card';
 import type {VercelRequest, VercelResponse} from '@vercel/node';
 
-export default async (req: VercelRequest, res: VercelResponse) => {
-    const {username, theme: rawTheme = 'default'} = req.query;
-    if (typeof rawTheme !== 'string') {
-        res.status(400).send('theme must be a string');
-        return;
-    }
-    if (typeof username !== 'string') {
-        res.status(400).send('username must be a string');
-        return;
-    }
-    const theme = resolveThemeName(rawTheme);
-    const override = parseThemeColorOverride(req.query);
-    try {
-        let token = getGitHubToken(0);
-        let tokenIndex = 0;
-        while (true) {
-            try {
-                const cardSVG = await dispatchStatsSVG(username, theme, token, override);
-                res.setHeader('Content-Type', 'image/svg+xml');
-                res.setHeader('Cache-Control', CONST_CACHE_CONTROL);
-                res.send(cardSVG);
-                // Fire-and-forget: don't block the response on analytics
-                void sendAnalytics('stats_card', {username, theme}, req.headers);
-                return;
-            } catch (err: any) {
-                console.log(err.message);
-                // We update github token and try again, until getNextGitHubToken throw an Error
-                if (err.response && (err.response.status === 403 || err.response.status === 401)) {
-                    tokenIndex += 1;
-                    token = getGitHubToken(tokenIndex);
-                } else {
-                    throw err;
-                }
-            }
-        }
-    } catch (err: any) {
-        console.log(err);
-        res.setHeader('Content-Type', 'image/svg+xml');
-        res.send(getErrorMsgCard(err.message, theme));
-    }
-};
+export default (req: VercelRequest, res: VercelResponse) =>
+    handleCard(req, res, 'stats_card', (username, theme, override, token) =>
+        dispatchStatsSVG(username, theme, token, override)
+    );

--- a/api/utils/github-token-updater.ts
+++ b/api/utils/github-token-updater.ts
@@ -1,13 +1,13 @@
 export const getGitHubToken = function (index: number): string {
+    if (isNaN(index)) {
+        throw new Error('Token index must be a number');
+    }
     const tokenName = `GITHUB_TOKEN_${index}`;
     // Fallback to GITHUB_TOKEN for index 0 if specific token not found (optional, but good for backward compat or single token setup)
     const token = process.env[tokenName] || (index === 0 ? process.env.GITHUB_TOKEN : undefined);
 
     if (!token) {
         throw new Error(`No more GITHUB_TOKEN can be used (Index: ${index})`);
-    }
-    if (isNaN(index)) {
-        throw new Error('Token index must be a number');
     }
 
     // Explicitly determine which token source is used for logging

--- a/api/utils/handle-card.ts
+++ b/api/utils/handle-card.ts
@@ -1,0 +1,79 @@
+import {getGitHubToken} from './github-token-updater';
+import {getErrorMsgCard} from './error-card';
+import {sendAnalytics} from '../../src/utils/analytics';
+import {CONST_CACHE_CONTROL} from '../../src/const/cache';
+import {resolveThemeName, parseThemeColorOverride, ThemeColorOverride} from '../../src/const/theme';
+import type {VercelRequest, VercelResponse} from '@vercel/node';
+
+// A card renderer receives the already-validated username, the resolved theme
+// name, the parsed color override and a GitHub token, and returns the SVG.
+export type CardRenderer = (
+    username: string,
+    theme: string,
+    override: ThemeColorOverride,
+    token: string
+) => Promise<string>;
+
+// Errors that mean "this token can't serve the request — try the next one":
+// 401/403 (auth or REST primary rate limit), 429 (secondary rate limit), and
+// GraphQL RATE_LIMITED (flagged by assertNoGraphQLErrors, which has no HTTP
+// status). The previous 401/403-only check missed 429 and the GraphQL-200 case,
+// so the multi-token rotation never engaged under real rate limits.
+function isRotatableError(err: any): boolean {
+    const status = err?.response?.status;
+    return status === 401 || status === 403 || status === 429 || err?.isRateLimit === true;
+}
+
+// Shared request handler for every card endpoint: validates username/theme,
+// resolves the theme + color overrides, runs the renderer while rotating GitHub
+// tokens on rate-limit/auth errors, sets headers, fires analytics, and renders a
+// friendly error card on failure.
+export async function handleCard(
+    req: VercelRequest,
+    res: VercelResponse,
+    eventName: string,
+    render: CardRenderer,
+    extraAnalytics: Record<string, unknown> = {}
+): Promise<void> {
+    const {username, theme: rawTheme = 'default'} = req.query;
+    if (typeof rawTheme !== 'string') {
+        res.status(400).send('theme must be a string');
+        return;
+    }
+    if (typeof username !== 'string') {
+        res.status(400).send('username must be a string');
+        return;
+    }
+    const theme = resolveThemeName(rawTheme);
+    const override = parseThemeColorOverride(req.query);
+
+    try {
+        let tokenIndex = 0;
+        let token = getGitHubToken(tokenIndex);
+        // Rotate through the configured tokens until one succeeds or getGitHubToken
+        // throws (no token at the next index).
+        while (true) {
+            try {
+                const cardSVG = await render(username, theme, override, token);
+                res.setHeader('Content-Type', 'image/svg+xml');
+                res.setHeader('Cache-Control', CONST_CACHE_CONTROL);
+                res.send(cardSVG);
+                // Fire-and-forget: don't block the response on analytics.
+                void sendAnalytics(eventName, {username, theme, ...extraAnalytics}, req.headers);
+                return;
+            } catch (err: any) {
+                console.log(err.message);
+                if (isRotatableError(err)) {
+                    tokenIndex += 1;
+                    token = getGitHubToken(tokenIndex);
+                } else {
+                    throw err;
+                }
+            }
+        }
+    } catch (err: any) {
+        console.log(err);
+        res.setHeader('Content-Type', 'image/svg+xml');
+        res.send(getErrorMsgCard(err.message, theme));
+    }
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,7 +19,7 @@ const execCmd = (cmd: string, args: string[] = []) =>
         const app = spawn(cmd, args, {stdio: 'pipe'});
         let stdout = '';
         app.stdout.on('data', data => {
-            stdout = data;
+            stdout += data;
         });
         app.on('close', code => {
             if (code !== 0 && !stdout.includes('nothing to commit')) {
@@ -175,6 +175,7 @@ const action = async () => {
                 retry += 1;
                 try {
                     await commitFile();
+                    break; // success — stop retrying
                 } catch (error) {
                     if (retry == maxRetry) {
                         throw error;

--- a/src/cards/profile-details-card.ts
+++ b/src/cards/profile-details-card.ts
@@ -125,9 +125,9 @@ const getProfileDetailsData = async function (
                   index: 0,
                   icon: Icon.GITHUB,
                   name: 'Contributions',
-                  value: `${abbreviateNumber(totalContributions, 2)} Contributions in ${
-                      profileDetails.contributionYears[0]
-                  }`
+                  value: profileDetails.contributionYears[0]
+                      ? `${abbreviateNumber(totalContributions, 2)} Contributions in ${profileDetails.contributionYears[0]}`
+                      : `${abbreviateNumber(totalContributions, 2)} Contributions on GitHub`
               },
         {
             index: 1,

--- a/src/cards/repos-per-language-card.ts
+++ b/src/cards/repos-per-language-card.ts
@@ -29,6 +29,12 @@ const getReposPerLanguageSVG = function (
     themeName: string,
     override?: ThemeColorOverride
 ) {
+    if (langData.length == 0) {
+        // Placeholder so accounts with no public repos/languages get a labelled
+        // donut instead of a blank one (mirrors the commit-language card).
+        langData.push({name: 'There are no', value: 1, color: '#586e75'});
+        langData.push({name: 'repos to show', value: 1, color: '#586e75'});
+    }
     const svgString = createDonutChartCard('Top Languages by Repo', langData, resolveTheme(themeName, override));
     return svgString;
 };

--- a/src/cards/stats-card.ts
+++ b/src/cards/stats-card.ts
@@ -48,7 +48,9 @@ const getStatsData = async function (
 
     const totalRepositoryContributions = profileDetails.totalRepositoryContributions;
     if (process.env.VERCEL) {
-        // If running on vercel, we only calculate for last 1 year to avoid Vercel timeout limit
+        // If running on vercel, we only calculate for last 1 year to avoid Vercel timeout limit.
+        // Sort descending first so we take the latest year (GitHub's order isn't guaranteed).
+        profileDetails.contributionYears.sort((a, b) => b - a);
         profileDetails.contributionYears = profileDetails.contributionYears.slice(0, 1);
         for (const year of profileDetails.contributionYears) {
             const contributions = await getContributionByYear(username, year, token);
@@ -79,7 +81,9 @@ const getStatsData = async function (
             : {
                   index: 1,
                   icon: Icon.COMMIT,
-                  name: `${profileDetails.contributionYears[0]} Commits:`,
+                  name: profileDetails.contributionYears[0]
+                      ? `${profileDetails.contributionYears[0]} Commits:`
+                      : 'Total Commits:',
                   value: `${abbreviateNumber(totalCommitContributions, 1)}`
               },
         {

--- a/src/github-api/commits-per-language.ts
+++ b/src/github-api/commits-per-language.ts
@@ -1,13 +1,14 @@
-import request from '../utils/request';
+import request, {assertNoGraphQLErrors} from '../utils/request';
 
 export class CommitLanguageInfo {
     name: string;
     color: string; // hexadecimal color code
     count: number;
 
-    constructor(name: string, color: string = '#586e75', count: number) {
+    constructor(name: string, color: string | null = '#586e75', count: number) {
         this.name = name;
-        this.color = color;
+        // GitHub returns null (not just undefined) for some languages' color.
+        this.color = color || '#586e75';
         this.count = count;
     }
 }
@@ -15,7 +16,7 @@ export class CommitLanguageInfo {
 export class CommitLanguages {
     private languageMap = new Map<string, CommitLanguageInfo>();
 
-    public addLanguageCount(name: string, color: string, count: number): void {
+    public addLanguageCount(name: string, color: string | null, count: number): void {
         if (this.languageMap.has(name)) {
             const lang = this.languageMap.get(name)!;
             lang.count += count;
@@ -72,9 +73,7 @@ export async function getCommitLanguage(
         login: username
     });
 
-    if (res.data.errors) {
-        throw Error(res.data.errors[0].message || 'GetCommitLanguage failed');
-    }
+    assertNoGraphQLErrors(res, 'GetCommitLanguage failed');
 
     res.data.data.user.contributionsCollection.commitContributionsByRepository.forEach(
         (node: {

--- a/src/github-api/contributions-by-year.ts
+++ b/src/github-api/contributions-by-year.ts
@@ -1,4 +1,4 @@
-import request from '../utils/request';
+import request, {assertNoGraphQLErrors} from '../utils/request';
 
 export class ConrtibutionByYear {
     year: number;
@@ -11,27 +11,26 @@ export class ConrtibutionByYear {
     }
 }
 
-const fetcher = (token: string, variables: any, year: number) => {
+const fetcher = (token: string, variables: any) => {
+    // Pass the year window as GraphQL variables ($from/$to) instead of
+    // interpolating the year into the query string. Null from/to falls back to
+    // GitHub's default range (the past year).
     return request(
         {
             Authorization: `bearer ${token}`
         },
         {
             query: `
-      query ContributionsByYear($login: String!) {
+      query ContributionsByYear($login: String!, $from: DateTime, $to: DateTime) {
         user(login: $login) {
-            ${
-                year
-                    ? `contributionsCollection(from: "${year}-01-01T00:00:00Z", to: "${year}-12-31T23:59:59Z") {`
-                    : 'contributionsCollection {'
-            }
-                    totalCommitContributions
-                    contributionCalendar {
-                        totalContributions
-                    }
+            contributionsCollection(from: $from, to: $to) {
+                totalCommitContributions
+                contributionCalendar {
+                    totalContributions
                 }
             }
         }
+      }
       `,
             variables
         }
@@ -43,17 +42,13 @@ export async function getContributionByYear(
     year: number,
     token: string
 ): Promise<ConrtibutionByYear> {
-    const res = await fetcher(
-        token,
-        {
-            login: username
-        },
-        year
-    );
+    const res = await fetcher(token, {
+        login: username,
+        from: year ? `${year}-01-01T00:00:00Z` : null,
+        to: year ? `${year}-12-31T23:59:59Z` : null
+    });
 
-    if (res.data.errors) {
-        throw Error(res.data.errors[0].message || 'GetContributionByYear failed');
-    }
+    assertNoGraphQLErrors(res, 'GetContributionByYear failed');
 
     const user = res.data.data.user;
 

--- a/src/github-api/organization-commits-per-language.ts
+++ b/src/github-api/organization-commits-per-language.ts
@@ -1,8 +1,10 @@
 // Aggregates commit counts by primary language across an organization's top public repos.
 // Capped at MAX_REPOS to stay within GitHub rate limits and Vercel function timeouts.
 // Semantics differ from the per-user version: orgs do not have contributionsCollection,
-// so we sample the default-branch history of each top repo.
-import request from '../utils/request';
+// so we sum each top repo's total default-branch commit count (all authors, all
+// time) and attribute it to that repo's primary language. `first: 1` is used
+// only to satisfy the connection arg — we read `totalCount`, not the nodes.
+import request, {assertNoGraphQLErrors} from '../utils/request';
 import {CommitLanguages} from './commits-per-language';
 
 const MAX_REPOS = 50;
@@ -28,7 +30,7 @@ const fetcher = (token: string, variables: any) => {
                 defaultBranchRef {
                   target {
                     ... on Commit {
-                      history(first: 0) {
+                      history(first: 1) {
                         totalCount
                       }
                     }
@@ -58,9 +60,7 @@ export async function getOrganizationCommitLanguage(
         first: MAX_REPOS
     });
 
-    if (res.data.errors) {
-        throw Error(res.data.errors[0].message || 'GetOrganizationCommitLanguage failed');
-    }
+    assertNoGraphQLErrors(res, 'GetOrganizationCommitLanguage failed');
 
     const owner = res.data.data.repositoryOwner;
     if (!owner || owner.__typename !== 'Organization') {

--- a/src/github-api/organization-details.ts
+++ b/src/github-api/organization-details.ts
@@ -1,4 +1,4 @@
-import request from '../utils/request';
+import request, {assertNoGraphQLErrors} from '../utils/request';
 
 export class OrganizationDetails {
     id: number;
@@ -87,9 +87,7 @@ export async function getOrganizationDetails(login: string, token: string): Prom
     while (hasNextPage) {
         const res: any = await fetcher(token, {login: login, endCursor: cursor});
 
-        if (res.data.errors) {
-            throw Error(res.data.errors[0].message || 'GetOrganizationDetails failed');
-        }
+        assertNoGraphQLErrors(res, 'GetOrganizationDetails failed');
 
         const owner = res.data.data.repositoryOwner;
         if (!owner || owner.__typename !== 'Organization') {

--- a/src/github-api/organization-repos-per-language.ts
+++ b/src/github-api/organization-repos-per-language.ts
@@ -1,4 +1,4 @@
-import request from '../utils/request';
+import request, {assertNoGraphQLErrors} from '../utils/request';
 import {RepoLanguages} from './repos-per-language';
 
 const fetcher = (token: string, variables: any) => {
@@ -49,9 +49,7 @@ export async function getOrganizationRepoLanguages(
 
     while (hasNextPage) {
         const res: any = await fetcher(token, {login: login, endCursor: cursor});
-        if (res.data.errors) {
-            throw Error(res.data.errors[0].message || 'GetOrganizationRepoLanguage fail');
-        }
+        assertNoGraphQLErrors(res, 'GetOrganizationRepoLanguage fail');
         const owner = res.data.data.repositoryOwner;
         if (!owner || owner.__typename !== 'Organization') {
             throw Error(`Organization not found: ${login}`);

--- a/src/github-api/owner-type.ts
+++ b/src/github-api/owner-type.ts
@@ -1,4 +1,4 @@
-import request from '../utils/request';
+import request, {assertNoGraphQLErrors} from '../utils/request';
 
 export type OwnerType = 'User' | 'Organization';
 
@@ -25,9 +25,7 @@ export async function getOwnerType(login: string, token: string): Promise<OwnerT
         login: login
     });
 
-    if (res.data.errors) {
-        throw Error(res.data.errors[0].message || 'GetOwnerType failed');
-    }
+    assertNoGraphQLErrors(res, 'GetOwnerType failed');
 
     const owner = res.data.data.repositoryOwner;
     if (!owner) {

--- a/src/github-api/productive-time.ts
+++ b/src/github-api/productive-time.ts
@@ -1,4 +1,4 @@
-import request from '../utils/request';
+import request, {assertNoGraphQLErrors} from '../utils/request';
 
 export class ProfuctiveTime {
     productiveDate: Date[] = [];
@@ -91,9 +91,7 @@ export async function getProductiveTime(
         since: since
     });
 
-    if (res.data.errors) {
-        throw Error(res.data.errors[0].message || 'GetProductiveTime failed');
-    }
+    assertNoGraphQLErrors(res, 'GetProductiveTime failed');
 
     const productiveTime = new ProfuctiveTime();
     res.data.data.user.contributionsCollection.commitContributionsByRepository.forEach(

--- a/src/github-api/profile-details.ts
+++ b/src/github-api/profile-details.ts
@@ -1,4 +1,4 @@
-import request from '../utils/request';
+import request, {assertNoGraphQLErrors} from '../utils/request';
 
 export class ProfileDetails {
     id: number; // user id
@@ -94,9 +94,7 @@ export async function getProfileDetails(username: string, token: string): Promis
         login: username
     });
 
-    if (res.data.errors) {
-        throw Error(res.data.errors[0].message || 'GetProfileDetails failed');
-    }
+    assertNoGraphQLErrors(res, 'GetProfileDetails failed');
 
     const user = res.data.data.user;
     const profileDetails = new ProfileDetails(user.id, user.name, user.email, user.createdAt);

--- a/src/github-api/repos-per-language.ts
+++ b/src/github-api/repos-per-language.ts
@@ -1,13 +1,14 @@
-import request from '../utils/request';
+import request, {assertNoGraphQLErrors} from '../utils/request';
 
 export class RepoLanguageInfo {
     name: string;
     color: string; // hexadecimal color code
     count: number;
 
-    constructor(name: string, color: string = '#586e75', count: number) {
+    constructor(name: string, color: string | null = '#586e75', count: number) {
         this.name = name;
-        this.color = color;
+        // GitHub returns null (not just undefined) for some languages' color.
+        this.color = color || '#586e75';
         this.count = count;
     }
 }
@@ -15,7 +16,7 @@ export class RepoLanguageInfo {
 export class RepoLanguages {
     private languageMap = new Map<string, RepoLanguageInfo>();
 
-    public addLanguage(name: string, color: string): void {
+    public addLanguage(name: string, color: string | null): void {
         if (this.languageMap.has(name)) {
             const lang = this.languageMap.get(name)!;
             lang.count += 1;
@@ -76,9 +77,7 @@ export async function getRepoLanguages(
 
     while (hasNextPage) {
         const res: any = await fetcher(token, {login: username, endCursor: cursor});
-        if (res.data.errors) {
-            throw Error(res.data.errors[0].message || 'GetRepoLanguage fail');
-        }
+        assertNoGraphQLErrors(res, 'GetRepoLanguage fail');
         const repos = res.data.data.user.repositories;
         nodes.push(...repos.nodes);
         cursor = repos.pageInfo?.endCursor ?? null;

--- a/src/utils/owner-dispatch.ts
+++ b/src/utils/owner-dispatch.ts
@@ -26,7 +26,14 @@ async function dispatch(userRender: () => Promise<string>, orgRender: () => Prom
         return await userRender();
     } catch (err) {
         if (isAuthOrRateLimit(err)) throw err;
-        return orgRender();
+        try {
+            return await orgRender();
+        } catch {
+            // Login isn't a user and isn't a resolvable org either — surface the
+            // original user-pipeline error (e.g. a mistyped username) instead of
+            // the less-relevant "Organization not found".
+            throw err;
+        }
     }
 }
 

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -4,6 +4,28 @@ import axios, {AxiosPromise} from 'axios';
 
 rax.attach();
 
+// An error thrown from the GraphQL layer, optionally flagged as a rate-limit so
+// callers can rotate to another token.
+export interface GraphQLError extends Error {
+    isRateLimit?: boolean;
+}
+
+// GitHub's GraphQL API returns rate-limit failures as HTTP 200 with an `errors`
+// array (type `RATE_LIMITED`), not an HTTP status — so axios never rejects and
+// `err.response.status` is never 429/403. Centralise the check here: throw on any
+// GraphQL error and mark rate-limit ones so the card handler rotates tokens
+// instead of immediately rendering an error card.
+export function assertNoGraphQLErrors(res: any, fallbackMessage: string): void {
+    const errors = res?.data?.errors;
+    if (Array.isArray(errors) && errors.length > 0) {
+        const err: GraphQLError = new Error(errors[0].message || fallbackMessage);
+        if (errors.some((e: any) => e?.type === 'RATE_LIMITED')) {
+            err.isRateLimit = true;
+        }
+        throw err;
+    }
+}
+
 export default function request(header: any, data: any): AxiosPromise<any> {
     // GitHub's API requires a User-Agent header; without it the edge returns 502.
     // Callers can override via `header`, but we provide a sensible default.

--- a/tests/github-api/language-color.test.ts
+++ b/tests/github-api/language-color.test.ts
@@ -1,0 +1,16 @@
+import {RepoLanguages} from '../../src/github-api/repos-per-language';
+import {CommitLanguages} from '../../src/github-api/commits-per-language';
+
+describe('language color null handling', () => {
+    it('RepoLanguages falls back to the default color when color is null', () => {
+        const r = new RepoLanguages();
+        r.addLanguage('X', null);
+        expect(r.getLanguageMap().get('X')!.color).toBe('#586e75');
+    });
+
+    it('CommitLanguages falls back to the default color when color is null', () => {
+        const c = new CommitLanguages();
+        c.addLanguageCount('Y', null, 3);
+        expect(c.getLanguageMap().get('Y')!.color).toBe('#586e75');
+    });
+});

--- a/tests/utils/github-token-updater.test.ts
+++ b/tests/utils/github-token-updater.test.ts
@@ -1,0 +1,29 @@
+import {getGitHubToken} from '../../api/utils/github-token-updater';
+
+describe('getGitHubToken', () => {
+    const original = {...process.env};
+    afterEach(() => {
+        process.env = {...original};
+    });
+
+    it('throws for a NaN index (guard runs before token lookup)', () => {
+        expect(() => getGitHubToken(NaN)).toThrow('Token index must be a number');
+    });
+
+    it('falls back to GITHUB_TOKEN for index 0', () => {
+        process.env.GITHUB_TOKEN = 'tok0';
+        delete process.env.GITHUB_TOKEN_0;
+        expect(getGitHubToken(0)).toBe('tok0');
+    });
+
+    it('returns GITHUB_TOKEN_n for index n', () => {
+        process.env.GITHUB_TOKEN_2 = 'tok2';
+        expect(getGitHubToken(2)).toBe('tok2');
+    });
+
+    it('throws when no token exists at the given index', () => {
+        delete process.env.GITHUB_TOKEN;
+        delete process.env.GITHUB_TOKEN_5;
+        expect(() => getGitHubToken(5)).toThrow('No more GITHUB_TOKEN');
+    });
+});

--- a/tests/utils/request.test.ts
+++ b/tests/utils/request.test.ts
@@ -1,0 +1,34 @@
+import {assertNoGraphQLErrors} from '../../src/utils/request';
+
+describe('assertNoGraphQLErrors', () => {
+    it('does nothing when there are no errors', () => {
+        expect(() => assertNoGraphQLErrors({data: {data: {}}}, 'fallback')).not.toThrow();
+        expect(() => assertNoGraphQLErrors({data: {errors: []}}, 'fallback')).not.toThrow();
+    });
+
+    it('throws the first error message', () => {
+        expect(() => assertNoGraphQLErrors({data: {errors: [{message: 'boom'}]}}, 'fallback')).toThrow('boom');
+    });
+
+    it('uses the fallback message when the error has none', () => {
+        expect(() => assertNoGraphQLErrors({data: {errors: [{}]}}, 'fallback')).toThrow('fallback');
+    });
+
+    it('flags RATE_LIMITED errors with isRateLimit so callers can rotate tokens', () => {
+        expect.assertions(1);
+        try {
+            assertNoGraphQLErrors({data: {errors: [{type: 'RATE_LIMITED', message: 'limit'}]}}, 'fallback');
+        } catch (e: any) {
+            expect(e.isRateLimit).toBe(true);
+        }
+    });
+
+    it('does not flag non-rate-limit errors', () => {
+        expect.assertions(1);
+        try {
+            assertNoGraphQLErrors({data: {errors: [{type: 'NOT_FOUND', message: 'nope'}]}}, 'fallback');
+        } catch (e: any) {
+            expect(e.isRateLimit).toBeUndefined();
+        }
+    });
+});


### PR DESCRIPTION
Workstream A of the refactor/audit plan.

## Refactor — shared card handler
New `api/utils/handle-card.ts` (`handleCard`) centralises what all five card endpoints duplicated: username/theme validation, `resolveThemeName` + `parseThemeColorOverride`, the GitHub-token rotation loop, response headers, fire-and-forget analytics, and the error card. The five `api/cards/*.ts` handlers are now a few lines each. (Also fixes `repos-per-language` which was silently missing the error `console.log`.)

## Fix — token rotation actually engages under rate limits (high)
The rotation loop only advanced on HTTP **401/403**. GitHub GraphQL rate limits come back as **HTTP 200 with `errors[]` (`type: RATE_LIMITED`)** and secondary limits as **429** — neither matched, so the service rendered an error card instead of trying the next token, making the multi-token setup inert under load. Now every fetcher routes its error check through `assertNoGraphQLErrors()` (flags `RATE_LIMITED`), and rotation triggers on `401/403/429` or the rate-limit flag.

## Audit bug fixes
- **M1** stats card sorts `contributionYears` desc before taking the latest.
- **M2** empty `contributionYears` no longer renders "undefined Commits" / "in undefined".
- **M4** `utcOffset` validated + clamped to `[-12,14]`.
- **M5** action commit retry loop `break`s on success; `execCmd` accumulates stdout.
- **M6** owner-dispatch surfaces the original user error when the org fallback also fails.
- **M7** org commits-per-language uses `history(first: 1)`; semantics documented.
- **L3** `null` language color falls back to default (no more `fill="null"`).
- **L4** repos-per-language shows a placeholder donut when a user has no languages.
- **L5** token-updater NaN guard runs before the token lookup.
- **L6** contributions-by-year passes the year window via GraphQL variables.

## Verification
`npm run build`, `npm run lint`, `npm test` all pass — **25 suites / 100 tests** (added tests for `assertNoGraphQLErrors`, `getGitHubToken`, color fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent handling for card requests, including clearer error cards and improved retry behavior during service limits.
  * Empty language data now displays a labeled placeholder chart instead of a blank visualization.
* **Bug Fixes**
  * Fixed missing contribution years in profile and statistics cards.
  * Improved handling of unavailable language colors with a default color.
  * Corrected organization fallback behavior and contribution-year calculations.
* **Reliability**
  * Improved detection and handling of API errors and rate limits across card data requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->