### PR TITLE
chore(dx): live-reload dev server, CI gates, faster pre-commit

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -47,3 +47,6 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npm run lint
+    - run: npm run format-check
+    - run: npm run typecheck
+    - run: npm run build

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Always set an expiration (90 days is a good default) and copy the token immediat
 
 Where the token lives depends on how you're running the tool. Same token, different home.
 
-#### Local development (`npm run test:local` or `vercel dev`)
+#### Local development (`npm run dev`, `npm run test:local`, or `vercel dev`)
 
 Copy `.env.example` to `.env` in the repo root and paste the token in:
 
@@ -186,7 +186,12 @@ Copy `.env.example` to `.env` in the repo root and paste the token in:
 GITHUB_TOKEN=your_github_token_here
 ```
 
-`.env` is already in [.gitignore](.gitignore) — do not commit it. Both `npm run test:local` and `vercel dev` auto-load this file.
+`.env` is already in [.gitignore](.gitignore) — do not commit it. All of the commands below auto-load it.
+
+Three ways to preview locally:
+- **`npm run dev`** — runs the real card handlers on a local server at `http://localhost:3000/` and live-reloads on save; type a user or org login to render every card. Best for iterating.
+- **`npm run test:local -- <login> [utcOffset] [exclude]`** — renders all cards for one login to `profile-summary-card-output/`.
+- **`vercel dev`** — full Vercel emulation of the API routes and the `/demo` page.
 
 #### GitHub Actions (production card refresh on your profile repo)
 

--- a/devbox.json
+++ b/devbox.json
@@ -14,7 +14,9 @@
         "scripts": {
             "test": "npm test",
             "build": "npm run build",
-            "package": "npm run package"
+            "package": "npm run package",
+            "dev": "npm run dev",
+            "test:local": "npm run test:local"
         }
     }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
     setupFilesAfterEnv: [],
     testMatch: ['**/*.test.ts'],
     verbose: true,
-    collectCoverageFrom: ['**/*.{ts,jx}', '!**/node_modules/**', '!**/dist/**', '!**/lib/**', '!scripts/**'],
+    collectCoverageFrom: ['**/*.{ts,tsx}', '!**/node_modules/**', '!**/dist/**', '!**/lib/**', '!scripts/**'],
     moduleNameMapper: {
         '^axios$': path.join(__dirname, 'node_modules/axios/dist/node/axios.cjs')
     },

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
         "lint": "eslint '**/*.ts'",
         "package": "ncc build --source-map --license licenses.txt",
         "test": "jest --passWithNoTests --reporters=default --reporters=jest-junit --coverage",
+        "test:unit": "jest --passWithNoTests",
+        "typecheck": "tsc --noEmit -p tsconfig.test.json",
         "test:local": "ts-node scripts/local-test.ts",
-        "dev": "ts-node scripts/dev-server.ts",
+        "dev": "node --watch -r ts-node/register scripts/dev-server.ts",
         "run": "node -r dotenv/config lib/app.js",
         "all": "npm run build && npm run format && npm run lint && npm run package && npm test"
     },
@@ -57,7 +59,7 @@
         "typescript": "5.4.5"
     },
     "pre-commit": [
-        "test",
+        "test:unit",
         "lint"
     ],
     "engines": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
         "rootDir": "./src",
         "strict": true,
         "noImplicitAny": true,
-        "esModuleInterop": true
+        "esModuleInterop": true,
+        "skipLibCheck": true
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
Developer-experience improvements (Workstream D of the roadmap).

## Local preview
- `npm run dev` now runs the existing local card server under `node --watch`, so it **live-reloads on save**. Open http://localhost:3000/, type a user/org login, see every card render through the real handlers.
- README documents the three local options (`npm run dev` / `npm run test:local` / `vercel dev`).

## CI gaps closed
`test-and-lint` previously ran only `test` + `lint`. Added **format-check**, **typecheck**, and **build** steps.
- typecheck runs `tsc --noEmit -p tsconfig.test.json`, which (unlike the build config) covers `api/` and `scripts/`.
- Added `skipLibCheck` to `tsconfig.json` — the only type errors were inside `@vercel/*` `node_modules` `.d.ts` files, not our code; this also speeds up the build.

## Faster feedback
- `test:unit` (jest without coverage/junit reporters) for quick local runs.
- pre-commit hook now runs `test:unit` + `lint` instead of the full coverage suite.
- Fixed `collectCoverageFrom` glob typo `{ts,jx}` → `{ts,tsx}`.

## devbox
Exposed `dev` and `test:local` devbox scripts.

## Verification
`npm run typecheck`, `format-check`, `build`, `lint`, `test` (25 suites / 100 tests) all pass; `npm run dev` smoke-tested (serves localhost:3000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded local development guidance with live-reload and local test preview options.
  * Added clearer environment setup instructions, including the required GitHub token example and `.env` safety notes.

* **Developer Experience**
  * Added convenient commands for development, unit testing, type checking, formatting checks, and production builds.
  * Improved automated validation and coverage checks to catch issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->