### PR TITLE
chore: add Buy Me a Coffee button

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
       <img alt="conventionalcommits" src="https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?style=for-the-badge&logo=conventionalcommits&color=ee99a0&logoColor=D9E0EE&labelColor=302D41"></a>
       <a href="https://github.com/vn7n24fzkq/github-profile-summary-cards/actions/workflows/github-action.yml">
       <img alt="testandlint" src="https://img.shields.io/github/actions/workflow/status/vn7n24fzkq/github-profile-summary-cards/test-and-lint.yml?branch=main&label=Test%20and%20Lint&style=for-the-badge&color=a6da95"></a>
+      <a href="https://buymeacoffee.com/vn7n24fzkq">
+      <img alt="Buy Me A Coffee" src="https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-FFDD00?style=for-the-badge&logo=buymeacoffee&logoColor=black&labelColor=302D41"></a>
    </p>
 </div>
 

--- a/api/pages/demo.html
+++ b/api/pages/demo.html
@@ -228,6 +228,23 @@
                 </v-main>
             </v-app>
         </div>
+        <!-- Buy Me a Coffee button. Kept outside the Vue #app so Vue's virtual DOM
+             never re-renders over the widget the script injects. -->
+        <div style="text-align: center; margin: 24px 0">
+            <script
+                type="text/javascript"
+                src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js"
+                data-name="bmc-button"
+                data-slug="vn7n24fzkq"
+                data-color="#FFDD00"
+                data-emoji=""
+                data-font="Poppins"
+                data-text="Buy me a coffee"
+                data-outline-color="#000000"
+                data-font-color="#000000"
+                data-coffee-color="#ffffff"
+            ></script>
+        </div>
         <script async defer src="https://buttons.github.io/buttons.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/vue@2.x/dist/vue.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.js"></script>

--- a/docs/README_zh-CN.md
+++ b/docs/README_zh-CN.md
@@ -18,6 +18,8 @@
       <img alt="conventionalcommits" src="https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?style=for-the-badge&logo=conventionalcommits&color=ee99a0&logoColor=D9E0EE&labelColor=302D41"></a>
       <a href="https://github.com/vn7n24fzkq/github-profile-summary-cards/actions/workflows/github-action.yml">
       <img alt="testandlint" src="https://img.shields.io/github/actions/workflow/status/vn7n24fzkq/github-profile-summary-cards/test-and-lint.yml?branch=main&label=Test%20and%20Lint&style=for-the-badge&color=a6da95"></a>
+      <a href="https://buymeacoffee.com/vn7n24fzkq">
+      <img alt="Buy Me A Coffee" src="https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-FFDD00?style=for-the-badge&logo=buymeacoffee&logoColor=black&labelColor=302D41"></a>
    </p>
 </div>
 


### PR DESCRIPTION
Adds a Buy Me a Coffee link in two places, per request.

- **README** (and `docs/README_zh-CN.md`): a Buy Me a Coffee badge in the header badge row. GitHub strips `<script>`, so this uses a shields.io badge image linking to the page.
- **Landing page** (`api/pages/demo.html`): the official Buy Me a Coffee button widget (`button.prod.min.js`, slug `vn7n24fzkq`). Placed just outside the Vue `#app` so Vue's virtual DOM doesn't re-render over the markup the widget script injects.

Links to https://buymeacoffee.com/vn7n24fzkq (verified — the page belongs to Casper).

Note: the upcoming landing-page rewrite (roadmap PR 4) will carry this button into the new page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Buy Me a Coffee” support badge to the English and Chinese documentation.
  * Added a “Buy Me a Coffee” button to the demo page for convenient access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->