### PR TITLE
chore: Buy Me a Coffee button uses Bree font

### DIFF
--- a/api/pages/demo.html
+++ b/api/pages/demo.html
@@ -238,7 +238,7 @@
                 data-slug="vn7n24fzkq"
                 data-color="#FFDD00"
                 data-emoji=""
-                data-font="Poppins"
+                data-font="Bree"
                 data-text="Buy me a coffee"
                 data-outline-color="#000000"
                 data-font-color="#000000"


### PR DESCRIPTION
Follow-up to #267: switch the Buy Me a Coffee button font from `Poppins` to `Bree` (the style Casper picked). One-attribute change in `api/pages/demo.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Buy Me a Coffee widget button font from Poppins to Bree for a refreshed visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->