### PR TITLE
docs: official Buy Me a Coffee button in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,15 @@
       <img alt="conventionalcommits" src="https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?style=for-the-badge&logo=conventionalcommits&color=ee99a0&logoColor=D9E0EE&labelColor=302D41"></a>
       <a href="https://github.com/vn7n24fzkq/github-profile-summary-cards/actions/workflows/github-action.yml">
       <img alt="testandlint" src="https://img.shields.io/github/actions/workflow/status/vn7n24fzkq/github-profile-summary-cards/test-and-lint.yml?branch=main&label=Test%20and%20Lint&style=for-the-badge&color=a6da95"></a>
-      <a href="https://buymeacoffee.com/vn7n24fzkq">
-      <img alt="Buy Me A Coffee" src="https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-FFDD00?style=for-the-badge&logo=buymeacoffee&logoColor=black&labelColor=302D41"></a>
    </p>
 </div>
 
 <div align="center">
 <p>
 <a href="https://github-profile-summary-cards.vercel.app/demo.html">Get your own cards now!!</a>
+</p>
+<p>
+<a href="https://www.buymeacoffee.com/vn7n24fzkq" target="_blank" rel="noopener"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me a Coffee" height="50"></a>
 </p>
 
 


### PR DESCRIPTION
Match the landing page: replace the small shields BMC badge with the official Buy Me a Coffee image button. Moved it out of the `for-the-badge` header row (where a 60px button looked oversized) into the centered intro block under "Get your own cards now!!".

🤖 Generated with [Claude Code](https://claude.com/claude-code)