### PR TITLE
fix: remove d3-color override to resolve ESM runtime error on Vercel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -133,7 +133,6 @@
             "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.7",
                 "@babel/generator": "^7.29.7",
@@ -3032,7 +3031,6 @@
             "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
             "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@octokit/auth-token": "^4.0.0",
                 "@octokit/graphql": "^7.1.0",
@@ -3667,7 +3665,6 @@
             "integrity": "sha512-FuLxeLuSVOqHPxSN1fkcD8DLU21gAP7nCKqGRJ/FglbCUBs0NYN6TpHcdmyLeh8C0KwGIaZQJSv+OYG+KZz+Gw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
@@ -3720,7 +3717,6 @@
             "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
                 "@typescript-eslint/scope-manager": "7.18.0",
@@ -3755,7 +3751,6 @@
             "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "7.18.0",
                 "@typescript-eslint/types": "7.18.0",
@@ -4342,7 +4337,6 @@
             "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -4411,7 +4405,6 @@
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
             "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -4574,7 +4567,6 @@
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
             "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
@@ -4960,7 +4952,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -5354,15 +5345,6 @@
                 "d3-path": "1 - 2"
             }
         },
-        "node_modules/d3-color": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/d3-contour": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-2.0.0.tgz",
@@ -5475,6 +5457,12 @@
                 "d3-color": "1 - 2"
             }
         },
+        "node_modules/d3-interpolate/node_modules/d3-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+            "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+            "license": "BSD-3-Clause"
+        },
         "node_modules/d3-path": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
@@ -5522,12 +5510,17 @@
                 "d3-interpolate": "1 - 2"
             }
         },
+        "node_modules/d3-scale-chromatic/node_modules/d3-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+            "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+            "license": "BSD-3-Clause"
+        },
         "node_modules/d3-selection": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
             "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/d3-shape": {
             "version": "2.1.0",
@@ -5578,6 +5571,12 @@
                 "d3-selection": "2"
             }
         },
+        "node_modules/d3-transition/node_modules/d3-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+            "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+            "license": "BSD-3-Clause"
+        },
         "node_modules/d3-zoom": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
@@ -5590,6 +5589,12 @@
                 "d3-selection": "2",
                 "d3-transition": "2"
             }
+        },
+        "node_modules/d3/node_modules/d3-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+            "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/data-urls": {
             "version": "2.0.0",
@@ -5922,7 +5927,6 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -5991,7 +5995,6 @@
             "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -7324,7 +7327,6 @@
             "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "30.2.0",
                 "@jest/types": "30.2.0",
@@ -9050,7 +9052,6 @@
             "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -9905,7 +9906,6 @@
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -10056,7 +10056,6 @@
             "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "overrides": {
         "undici": "^6.27.0",
         "@tootallnate/once": "^2.0.1",
-        "d3-color": "^3.1.0",
         "js-yaml@^3.0.0": "^3.15.0",
         "js-yaml@^4.0.0": "^4.2.0",
         "node-fetch@^2.0.0": "^2.6.7",


### PR DESCRIPTION
### Problem
An override was added to force `d3-color` to `^3.1.0` to address a security alert (ReDoS vulnerability). However, `d3-color` v3 is an ES Module (ESM) only package. This causes Vercel serverless function deployments to fail at runtime with the `[ERR_REQUIRE_ESM]` error since the Vercel execution environment runs in CommonJS and does not support `require(ESM)`.

### Solution
This PR removes the `d3-color` override from `package.json`, which resolves the dependency to `d3-color@2.0.0` (CommonJS compatible). Since the project specifies static theme definitions and does not process dynamic, user-controlled color inputs through `d3-color`, the ReDoS vulnerability is not reachable or exploitable in this application.

All local unit tests run and pass successfully with this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an outdated package version override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->