### PR TITLE
feat(landing): show live star count on the GitHub button

### DIFF
--- a/api/pages/demo.html
+++ b/api/pages/demo.html
@@ -126,6 +126,13 @@
                 color: var(--accent-fg);
                 border-color: var(--accent);
             }
+            .btn .count {
+                font-size: 0.85em;
+                border: 1px solid var(--border);
+                border-radius: 999px;
+                padding: 0 0.5em;
+                background: var(--bg);
+            }
 
             .layout {
                 display: grid;
@@ -295,7 +302,7 @@
                         href="https://github.com/vn7n24fzkq/github-profile-summary-cards"
                         target="_blank"
                         rel="noopener"
-                        >★ Star on GitHub</a
+                        >★ Star on GitHub <span class="count" id="starCount" hidden></span></a
                     >
                 </div>
                 <p class="sub">
@@ -667,6 +674,37 @@
                     .catch(function () {
                         fillThemes(FALLBACK_THEMES);
                     });
+
+                // ---- Live star count on the GitHub button ----
+                // Unauthenticated GitHub API is limited to 60 req/h per client IP,
+                // so cache the count for an hour; on any failure just leave the
+                // badge hidden — the button works fine without it.
+                (function () {
+                    var el = document.getElementById('starCount');
+                    function show(n) {
+                        el.textContent = n >= 1000 ? (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k' : String(n);
+                        el.hidden = false;
+                    }
+                    try {
+                        var cached = JSON.parse(sessionStorage.getItem('gpsc-stars') || 'null');
+                        if (cached && Date.now() - cached.at < 3600000) return show(cached.n);
+                    } catch (e) {}
+                    fetch('https://api.github.com/repos/vn7n24fzkq/github-profile-summary-cards')
+                        .then(function (r) {
+                            return r.ok ? r.json() : null;
+                        })
+                        .then(function (d) {
+                            if (!d || typeof d.stargazers_count !== 'number') return;
+                            show(d.stargazers_count);
+                            try {
+                                sessionStorage.setItem(
+                                    'gpsc-stars',
+                                    JSON.stringify({n: d.stargazers_count, at: Date.now()})
+                                );
+                            } catch (e) {}
+                        })
+                        .catch(function () {});
+                })();
             })();
         </script>
     </body>


### PR DESCRIPTION
Adds a live star-count badge to the **★ Star on GitHub** button on the landing page.

- Fetched client-side from the GitHub API on page load
- Cached in `sessionStorage` for 1 hour (visitors use their own unauthenticated quota, 60 req/h per IP — one request per visitor per hour at most)
- Formats as `1.2k` above 1000
- On any failure the badge stays hidden; the button itself is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GitHub star count badge beside the “Star on GitHub” link.
  * Displays abbreviated counts, such as 1.2k, for larger numbers.
  * Temporarily caches the count to improve loading efficiency.

* **Bug Fixes**
  * The badge remains hidden if the count cannot be loaded, while the GitHub link continues to work normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->