### PR TITLE
feat(stats): add hide_logo option to remove the GitHub logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ Values are hex **without** the leading `#` — 3, 4, 6, or 8 digits (the 4/8-dig
 
 Resolves [#110](https://github.com/vn7n24fzkq/github-profile-summary-cards/issues/110) and [#152](https://github.com/vn7n24fzkq/github-profile-summary-cards/issues/152).
 
+The stats card also accepts `hide_logo=true` to remove the GitHub logo on the right:
+
+`http://github-profile-summary-cards.vercel.app/api/cards/stats?username=vn7n24fzkq&theme=dark&hide_logo=true`
+
 ### Animations ✨ (new)
 
 Cards can now **animate**! Add an optional `animation` parameter and the card plays a pure-CSS entrance when it loads — no GIFs, no JavaScript, works right inside your GitHub README. The background/frame appears instantly and the animation plays on the individual pieces (each stat row, each language, each bar), so it reads as the content filling into a ready card.

--- a/api/cards/stats.ts
+++ b/api/cards/stats.ts
@@ -2,7 +2,10 @@ import {dispatchStatsSVG} from '../../src/utils/owner-dispatch';
 import {handleCard} from '../utils/handle-card';
 import type {VercelRequest, VercelResponse} from '@vercel/node';
 
-export default (req: VercelRequest, res: VercelResponse) =>
-    handleCard(req, res, 'stats_card', (username, theme, override, token) =>
-        dispatchStatsSVG(username, theme, token, override)
+export default (req: VercelRequest, res: VercelResponse) => {
+    // Opt-in flag to drop the big GitHub logo on the right of the stats card.
+    const hideLogo = req.query.hide_logo === 'true';
+    return handleCard(req, res, 'stats_card', (username, theme, override, token) =>
+        dispatchStatsSVG(username, theme, token, override, hideLogo)
     );
+};

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,155 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "git": {
+      "resolved": "github:NixOS/nixpkgs/6cdc7fc76e8bf7fde9fa43a849fcaaa70e230dee#git",
+      "source": "nixpkg"
+    },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2026-07-13T04:04:42Z",
+      "resolved": "github:NixOS/nixpkgs/6cdc7fc76e8bf7fde9fa43a849fcaaa70e230dee?lastModified=1783915482"
+    },
+    "nodejs@24": {
+      "last_modified": "2025-12-27T12:56:01Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/3edc4a30ed3903fdf6f90c837f961fa6b49582d1#nodejs_24",
+      "source": "devbox-search",
+      "version": "24.12.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/b1h0af3yb3z9jz048phclcqw6ihiww67-nodejs-24.12.0",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/ksn4nj0nbp0ikmh4scy9x4biqqdswwhy-nodejs-24.12.0-dev"
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/3x72bm7l30ib7l7cximrp0sklcq8jqwy-nodejs-24.12.0-libv8"
+            }
+          ],
+          "store_path": "/nix/store/b1h0af3yb3z9jz048phclcqw6ihiww67-nodejs-24.12.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/9jfsyhcr9c6rpm94lrkibv75jkggvwss-nodejs-24.12.0",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/7izhv9x1yvsmyrhmmyps6bxjjclajm80-nodejs-24.12.0-dev"
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/8hl74pnc1qyz68rg10ixw7fz32hcxqkk-nodejs-24.12.0-libv8"
+            }
+          ],
+          "store_path": "/nix/store/9jfsyhcr9c6rpm94lrkibv75jkggvwss-nodejs-24.12.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/cj1243xswxvnwgifyiyg8axhn0r2vl48-nodejs-24.12.0",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/kzia3rkaf9vwpn3py23q9v49jpjm6zx7-nodejs-24.12.0-dev"
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/xszji81xj7ghjhz7jk0jkhb84nfwyd8f-nodejs-24.12.0-libv8"
+            }
+          ],
+          "store_path": "/nix/store/cj1243xswxvnwgifyiyg8axhn0r2vl48-nodejs-24.12.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/9z1v3wyrxp6fpyzw21lcakd5w7aknzyc-nodejs-24.12.0",
+              "default": true
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/5yvx909wlis13qd2y1ahwl7ij21ma69a-nodejs-24.12.0-libv8"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/7ll99p08gmpg0n048669p80zjibl5akr-nodejs-24.12.0-dev"
+            }
+          ],
+          "store_path": "/nix/store/9z1v3wyrxp6fpyzw21lcakd5w7aknzyc-nodejs-24.12.0"
+        }
+      }
+    },
+    "pre-commit": {
+      "resolved": "github:NixOS/nixpkgs/6cdc7fc76e8bf7fde9fa43a849fcaaa70e230dee#pre-commit",
+      "source": "nixpkg"
+    },
+    "python@3": {
+      "last_modified": "2026-06-27T07:37:20Z",
+      "plugin_version": "0.0.4",
+      "resolved": "github:NixOS/nixpkgs/3d46470bb3030020f7e1361f33514854f5bfa86d#python315",
+      "source": "devbox-search",
+      "version": "3.15.0b3",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/2s7acb0nbd4x8lssr43hn53c01svwcsa-python3-3.15.0b3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/2s7acb0nbd4x8lssr43hn53c01svwcsa-python3-3.15.0b3"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/yf8lmb734ab1lijs9wbzmw4gdw6swclq-python3-3.15.0b3",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/9iplbkmibb9zpv902yncq8s59h8znvar-python3-3.15.0b3-debug"
+            }
+          ],
+          "store_path": "/nix/store/yf8lmb734ab1lijs9wbzmw4gdw6swclq-python3-3.15.0b3"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/m2p1arbg3vrkjw7qh912kk9sfkcyqvab-python3-3.15.0b3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/m2p1arbg3vrkjw7qh912kk9sfkcyqvab-python3-3.15.0b3"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/nycpfzi42fk7r2n8k2cy7ymja4wydwh6-python3-3.15.0b3",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/1my7iy2i8jlicrj42wvdg62vzs5q2xlp-python3-3.15.0b3-debug"
+            }
+          ],
+          "store_path": "/nix/store/nycpfzi42fk7r2n8k2cy7ymja4wydwh6-python3-3.15.0b3"
+        }
+      }
+    }
+  }
+}

--- a/src/cards/organization-stats-card.ts
+++ b/src/cards/organization-stats-card.ts
@@ -19,20 +19,22 @@ export const getOrganizationStatsSVGWithThemeName = async function (
     login: string,
     themeName: string,
     token: string,
-    override?: ThemeColorOverride
+    override?: ThemeColorOverride,
+    hideLogo = false
 ) {
     if (!ThemeMap.has(themeName)) throw new Error('Theme does not exist');
     const statsData = await getOrganizationStatsData(login, token);
-    return getOrganizationStatsSVG(statsData, themeName, override);
+    return getOrganizationStatsSVG(statsData, themeName, override, hideLogo);
 };
 
 const getOrganizationStatsSVG = function (
     statsData: {index: number; icon: string; name: string; value: string}[],
     themeName: string,
-    override?: ThemeColorOverride
+    override?: ThemeColorOverride,
+    hideLogo = false
 ) {
     const title = 'Stats';
-    const svgString = statsCard(`${title}`, statsData, resolveTheme(themeName, override));
+    const svgString = statsCard(`${title}`, statsData, resolveTheme(themeName, override), hideLogo);
     return svgString;
 };
 

--- a/src/cards/stats-card.ts
+++ b/src/cards/stats-card.ts
@@ -16,20 +16,22 @@ export const getStatsSVGWithThemeName = async function (
     username: string,
     themeName: string,
     token: string,
-    override?: ThemeColorOverride
+    override?: ThemeColorOverride,
+    hideLogo = false
 ) {
     if (!ThemeMap.has(themeName)) throw new Error('Theme does not exist');
     const statsData = await getStatsData(username, token);
-    return getStatsSVG(statsData, themeName, override);
+    return getStatsSVG(statsData, themeName, override, hideLogo);
 };
 
 const getStatsSVG = function (
     StatsData: {index: number; icon: string; name: string; value: string}[],
     themeName: string,
-    override?: ThemeColorOverride
+    override?: ThemeColorOverride,
+    hideLogo = false
 ) {
     const title = 'Stats';
-    const svgString = statsCard(`${title}`, StatsData, resolveTheme(themeName, override));
+    const svgString = statsCard(`${title}`, StatsData, resolveTheme(themeName, override), hideLogo);
     return svgString;
 };
 

--- a/src/templates/stats-card.ts
+++ b/src/templates/stats-card.ts
@@ -5,7 +5,8 @@ import {Theme} from '../const/theme';
 export function createStatsCard(
     title: string,
     statsData: {index: number; icon: string; name: string; value: string}[],
-    theme: Theme
+    theme: Theme,
+    hideLogo = false
 ) {
     const card = new Card(title, 340, 200, theme);
     const svg = card.getSVG();
@@ -66,8 +67,10 @@ export function createStatsCard(
         .style('fill', theme.text)
         .style('font-size', `${labelHeight}px`);
 
-    const panelForGitHubLogo = svg.append('g').attr('transform', `translate(220,20)`);
-    panelForGitHubLogo.append('g').attr('transform', `scale(6)`).style('fill', theme.icon).html(Icon.GITHUB);
+    if (!hideLogo) {
+        const panelForGitHubLogo = svg.append('g').attr('transform', `translate(220,20)`);
+        panelForGitHubLogo.append('g').attr('transform', `scale(6)`).style('fill', theme.icon).html(Icon.GITHUB);
+    }
 
     return card.toString();
 }

--- a/src/templates/stats-card.ts
+++ b/src/templates/stats-card.ts
@@ -8,7 +8,10 @@ export function createStatsCard(
     theme: Theme,
     hideLogo = false
 ) {
-    const card = new Card(title, 340, 200, theme);
+    // Without the logo the right side is dead space; shrink the card so it
+    // actually frees room in side-by-side README layouts (#141): stat values
+    // end around x=220, +30 to mirror the left margin.
+    const card = new Card(title, hideLogo ? 250 : 340, 200, theme);
     const svg = card.getSVG();
 
     // draw icon

--- a/src/utils/owner-dispatch.ts
+++ b/src/utils/owner-dispatch.ts
@@ -80,10 +80,11 @@ export const dispatchStatsSVG = function (
     login: string,
     themeName: string,
     token: string,
-    override?: ThemeColorOverride
+    override?: ThemeColorOverride,
+    hideLogo = false
 ): Promise<string> {
     return dispatch(
-        () => getStatsSVGWithThemeName(login, themeName, token, override),
-        () => getOrganizationStatsSVGWithThemeName(login, themeName, token, override)
+        () => getStatsSVGWithThemeName(login, themeName, token, override, hideLogo),
+        () => getOrganizationStatsSVGWithThemeName(login, themeName, token, override, hideLogo)
     );
 };

--- a/tests/templates/stats-card.test.ts
+++ b/tests/templates/stats-card.test.ts
@@ -1,0 +1,20 @@
+import {createStatsCard} from '../../src/templates/stats-card';
+import {Icon} from '../../src/const/icon';
+import {ThemeMap} from '../../src/const/theme';
+
+const statsData = [{index: 0, icon: Icon.STAR, name: 'Total Stars:', value: '42'}];
+const theme = ThemeMap.get('default')!;
+
+describe('stats card template', () => {
+    it('renders the GitHub logo by default', () => {
+        const svg = createStatsCard('Stats', statsData, theme);
+        expect(svg).toContain(Icon.GITHUB);
+    });
+
+    it('omits the GitHub logo when hideLogo is set', () => {
+        const svg = createStatsCard('Stats', statsData, theme, true);
+        expect(svg).not.toContain(Icon.GITHUB);
+        // The rest of the card still renders.
+        expect(svg).toContain('Total Stars:');
+    });
+});

--- a/tests/templates/stats-card.test.ts
+++ b/tests/templates/stats-card.test.ts
@@ -17,4 +17,11 @@ describe('stats card template', () => {
         // The rest of the card still renders.
         expect(svg).toContain('Total Stars:');
     });
+
+    it('shrinks the card when the logo is hidden so it frees real space (#141)', () => {
+        const withLogo = createStatsCard('Stats', statsData, theme, false);
+        const withoutLogo = createStatsCard('Stats', statsData, theme, true);
+        expect(withLogo).toContain('width="340"');
+        expect(withoutLogo).toContain('width="250"');
+    });
 });


### PR DESCRIPTION
Adds an opt-in `hide_logo=true` query parameter to the stats card (user and organization variants) that removes the large GitHub logo on the right.

```
/api/cards/stats?username=vn7n24fzkq&theme=dark&hide_logo=true
```

- Default behaviour unchanged (logo shown)
- Documented in README, covered by template unit tests

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `hide_logo=true` parameter for stats card URLs.
  * When enabled, the GitHub logo is removed while keeping the rest of the stats card content intact.
  * Card layout adjusts to fit the hidden-logo version.
  * Logo remains visible by default.
* **Documentation**
  * Updated the “Custom colors” API docs with `hide_logo=true` and an example `stats` endpoint URL.
* **Tests**
  * Added tests covering default logo display, logo hiding, and the resulting SVG/layout differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->