### PR TITLE
feat: exclude specific repositories from language cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@
     - A comma separated list of languages to exclude, e.g., exclude=java,rust,jupyter%20Notebook
       - You can represent a space in the language list by using '%20' when you want to include a space.
     - You can found the supported languages in [here](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml)
+  - exclude_repos:
+    - A comma separated list of repository names to exclude (case-insensitive), e.g., exclude_repos=dotfiles,my-fork
 
 ### Top languages in commits card
 ![](docs/preview/api/most-commit-language.svg)
@@ -93,6 +95,9 @@
     - A comma separated list of languages to exclude, e.g., exclude=java,rust,jupyter%20Notebook
       - You can represent a space in the language list by using '%20' when you want to include a space.
     - You can found the supported languages in [here](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml)
+  - exclude_repos:
+    - A comma separated list of repository names to exclude (case-insensitive), e.g., exclude_repos=dotfiles,my-fork
+    - Commits can come from other owners' repos, so `owner/repo` entries also match, e.g., exclude_repos=someorg/website
 
 ### GitHub stats card
 ![](docs/preview/api/stats.svg)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@
     - You can found the supported languages in [here](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml)
   - exclude_repos:
     - A comma separated list of repository names to exclude (case-insensitive), e.g., exclude_repos=dotfiles,my-fork
+    - `owner/repo` entries also match, e.g., exclude_repos=vn7n24fzkq/dotfiles
 
 ### Top languages in commits card
 ![](docs/preview/api/most-commit-language.svg)

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,11 @@ inputs:
     required: false
     description: 'A comma separated list of languages to exclude'
     default: ''
+  EXCLUDE_REPOS:
+    type: string
+    required: false
+    description: 'A comma separated list of repository names to exclude from the language cards (case-insensitive; owner/repo also matches on the commits card)'
+    default: ''
   AUTO_PUSH:
     type: boolean
     required: false

--- a/api/cards/most-commit-language.ts
+++ b/api/cards/most-commit-language.ts
@@ -5,12 +5,20 @@ import type {VercelRequest, VercelResponse} from '@vercel/node';
 
 export default (req: VercelRequest, res: VercelResponse) => {
     const {exclude = ''} = req.query;
+    const excludeReposRaw = req.query.exclude_repos ?? '';
     if (typeof exclude !== 'string') {
         res.status(400).send('exclude must be a string');
         return;
     }
+    if (typeof excludeReposRaw !== 'string') {
+        res.status(400).send('exclude_repos must be a string');
+        return;
+    }
     const excludeArr = parseExcludeLanguages(exclude);
+    // Comma-separated repo names to skip (case-insensitive). Entries may be
+    // `repo` or `owner/repo` — commit contributions can live in others' repos.
+    const excludeReposArr = excludeReposRaw.split(',').map(val => val.trim().toLowerCase());
     return handleCard(req, res, 'most_commit_language_card', (username, theme, override, token) =>
-        dispatchMostCommitLanguageSVG(username, theme, excludeArr, token, override)
+        dispatchMostCommitLanguageSVG(username, theme, excludeArr, token, override, excludeReposArr)
     );
 };

--- a/api/cards/repos-per-language.ts
+++ b/api/cards/repos-per-language.ts
@@ -5,12 +5,19 @@ import type {VercelRequest, VercelResponse} from '@vercel/node';
 
 export default (req: VercelRequest, res: VercelResponse) => {
     const {exclude = ''} = req.query;
+    const excludeReposRaw = req.query.exclude_repos ?? '';
     if (typeof exclude !== 'string') {
         res.status(400).send('exclude must be a string');
         return;
     }
+    if (typeof excludeReposRaw !== 'string') {
+        res.status(400).send('exclude_repos must be a string');
+        return;
+    }
     const excludeArr = parseExcludeLanguages(exclude);
+    // Comma-separated repo names to skip (case-insensitive), e.g. exclude_repos=dotfiles,my-fork
+    const excludeReposArr = excludeReposRaw.split(',').map(val => val.trim().toLowerCase());
     return handleCard(req, res, 'repos_per_language_card', (username, theme, override, token) =>
-        dispatchReposPerLanguageSVG(username, theme, excludeArr, token, override)
+        dispatchReposPerLanguageSVG(username, theme, excludeArr, token, override, excludeReposArr)
     );
 };

--- a/src/app.ts
+++ b/src/app.ts
@@ -48,7 +48,8 @@ const generateUserCards = async (
     utcOffset: number,
     exclude: Array<string>,
     token: string,
-    options: CardGenerationOptions = {}
+    options: CardGenerationOptions = {},
+    excludeRepos: Array<string> = []
 ) => {
     // ProfileDetailsCard
     try {
@@ -62,7 +63,7 @@ const generateUserCards = async (
     // ReposPerLanguageCard
     try {
         core.info(`Creating ReposPerLanguageCard...`);
-        await createReposPerLanguageCard(username, exclude, token, options);
+        await createReposPerLanguageCard(username, exclude, token, options, excludeRepos);
     } catch (error: any) {
         core.error(`Error when creating ReposPerLanguageCard \n${error.stack}`);
     }
@@ -70,7 +71,7 @@ const generateUserCards = async (
     // CommitsPerLanguageCard
     try {
         core.info(`Creating CommitsPerLanguageCard...`);
-        await createCommitsPerLanguageCard(username, exclude, token, options);
+        await createCommitsPerLanguageCard(username, exclude, token, options, excludeRepos);
     } catch (error: any) {
         core.error(`Error when creating CommitsPerLanguageCard \n${error.stack}`);
     }
@@ -96,7 +97,8 @@ const generateOrganizationCards = async (
     login: string,
     exclude: Array<string>,
     token: string,
-    options: CardGenerationOptions = {}
+    options: CardGenerationOptions = {},
+    excludeRepos: Array<string> = []
 ) => {
     // ProfileDetailsCard
     try {
@@ -110,7 +112,7 @@ const generateOrganizationCards = async (
     // ReposPerLanguageCard
     try {
         core.info(`Creating Organization ReposPerLanguageCard...`);
-        await createOrganizationReposPerLanguageCard(login, exclude, token, options);
+        await createOrganizationReposPerLanguageCard(login, exclude, token, options, excludeRepos);
     } catch (error: any) {
         core.error(`Error when creating Organization ReposPerLanguageCard \n${error.stack}`);
     }
@@ -118,7 +120,7 @@ const generateOrganizationCards = async (
     // CommitsPerLanguageCard
     try {
         core.info(`Creating Organization CommitsPerLanguageCard...`);
-        await createOrganizationCommitsPerLanguageCard(login, exclude, token, options);
+        await createOrganizationCommitsPerLanguageCard(login, exclude, token, options, excludeRepos);
     } catch (error: any) {
         core.error(`Error when creating Organization CommitsPerLanguageCard \n${error.stack}`);
     }
@@ -149,6 +151,11 @@ const action = async () => {
     core.info(`UTC offset: ${utcOffset}`);
     const exclude = parseExcludeLanguages(core.getInput('EXCLUDE', {required: false}));
     core.info(`Excluded languages: ${exclude}`);
+    const excludeRepos = core
+        .getInput('EXCLUDE_REPOS', {required: false})
+        .split(',')
+        .map(val => val.trim().toLowerCase());
+    core.info(`Excluded repos: ${excludeRepos}`);
     const autoPush = core.getBooleanInput('AUTO_PUSH', {required: false});
     core.info(`You ${autoPush ? 'have' : "haven't"} set automatically push commits`);
 
@@ -188,9 +195,9 @@ const action = async () => {
         }
 
         if (ownerType === 'Organization') {
-            await generateOrganizationCards(username, exclude, process.env.GITHUB_TOKEN!, options);
+            await generateOrganizationCards(username, exclude, process.env.GITHUB_TOKEN!, options, excludeRepos);
         } else {
-            await generateUserCards(username, utcOffset, exclude, process.env.GITHUB_TOKEN!, options);
+            await generateUserCards(username, utcOffset, exclude, process.env.GITHUB_TOKEN!, options, excludeRepos);
         }
 
         // generate markdown

--- a/src/cards/most-commit-language-card.ts
+++ b/src/cards/most-commit-language-card.ts
@@ -7,9 +7,10 @@ export const createCommitsPerLanguageCard = async function (
     username: string,
     exclude: Array<string>,
     token: string,
-    options: CardGenerationOptions = {}
+    options: CardGenerationOptions = {},
+    excludeRepos: Array<string> = []
 ) {
-    const statsData = await getCommitsLanguageData(username, exclude, token);
+    const statsData = await getCommitsLanguageData(username, exclude, token, excludeRepos);
     // use 2- prefix for sort in preview
     writeThemedCards('2-most-commit-language', themeName => getCommitsLanguageSVG(statsData, themeName), options);
 };
@@ -19,10 +20,11 @@ export const getCommitsLanguageSVGWithThemeName = async function (
     themeName: string,
     exclude: Array<string>,
     token: string,
-    override?: ThemeColorOverride
+    override?: ThemeColorOverride,
+    excludeRepos: Array<string> = []
 ): Promise<string> {
     if (!ThemeMap.has(themeName)) throw new Error('Theme does not exist');
-    const langData = await getCommitsLanguageData(username, exclude, token);
+    const langData = await getCommitsLanguageData(username, exclude, token, excludeRepos);
     return getCommitsLanguageSVG(langData, themeName, override);
 };
 
@@ -53,9 +55,10 @@ const getCommitsLanguageSVG = function (
 const getCommitsLanguageData = async function (
     username: string,
     exclude: Array<string>,
-    token: string
+    token: string,
+    excludeRepos: Array<string> = []
 ): Promise<{name: string; value: number; color: string}[]> {
-    const commitLanguages: CommitLanguages = await getCommitLanguage(username, exclude, token);
+    const commitLanguages: CommitLanguages = await getCommitLanguage(username, exclude, token, excludeRepos);
     let langData = [];
 
     // make a pie data

--- a/src/cards/organization-most-commit-language-card.ts
+++ b/src/cards/organization-most-commit-language-card.ts
@@ -8,9 +8,10 @@ export const createOrganizationCommitsPerLanguageCard = async function (
     login: string,
     exclude: Array<string>,
     token: string,
-    options: CardGenerationOptions = {}
+    options: CardGenerationOptions = {},
+    excludeRepos: Array<string> = []
 ) {
-    const langData = await getOrganizationCommitsLanguageData(login, exclude, token);
+    const langData = await getOrganizationCommitsLanguageData(login, exclude, token, excludeRepos);
     // use 2- prefix for sort in preview
     writeThemedCards(
         '2-most-commit-language',
@@ -24,10 +25,11 @@ export const getOrganizationCommitsLanguageSVGWithThemeName = async function (
     themeName: string,
     exclude: Array<string>,
     token: string,
-    override?: ThemeColorOverride
+    override?: ThemeColorOverride,
+    excludeRepos: Array<string> = []
 ): Promise<string> {
     if (!ThemeMap.has(themeName)) throw new Error('Theme does not exist');
-    const langData = await getOrganizationCommitsLanguageData(login, exclude, token);
+    const langData = await getOrganizationCommitsLanguageData(login, exclude, token, excludeRepos);
     return getOrganizationCommitsLanguageSVG(langData, themeName, override);
 };
 
@@ -57,9 +59,10 @@ const getOrganizationCommitsLanguageSVG = function (
 const getOrganizationCommitsLanguageData = async function (
     login: string,
     exclude: Array<string>,
-    token: string
+    token: string,
+    excludeRepos: Array<string> = []
 ): Promise<{name: string; value: number; color: string}[]> {
-    const commitLanguages: CommitLanguages = await getOrganizationCommitLanguage(login, exclude, token);
+    const commitLanguages: CommitLanguages = await getOrganizationCommitLanguage(login, exclude, token, excludeRepos);
     let langData = [];
 
     // make a pie data

--- a/src/cards/organization-repos-per-language-card.ts
+++ b/src/cards/organization-repos-per-language-card.ts
@@ -7,9 +7,10 @@ export const createOrganizationReposPerLanguageCard = async function (
     login: string,
     exclude: Array<string>,
     token: string,
-    options: CardGenerationOptions = {}
+    options: CardGenerationOptions = {},
+    excludeRepos: Array<string> = []
 ) {
-    const langData = await getOrganizationRepoLanguageData(login, exclude, token);
+    const langData = await getOrganizationRepoLanguageData(login, exclude, token, excludeRepos);
     // use 1- prefix for sort in preview
     writeThemedCards(
         '1-repos-per-language',
@@ -23,10 +24,11 @@ export const getOrganizationReposPerLanguageSVGWithThemeName = async function (
     themeName: string,
     exclude: Array<string>,
     token: string,
-    override?: ThemeColorOverride
+    override?: ThemeColorOverride,
+    excludeRepos: Array<string> = []
 ) {
     if (!ThemeMap.has(themeName)) throw new Error('Theme does not exist');
-    const langData = await getOrganizationRepoLanguageData(login, exclude, token);
+    const langData = await getOrganizationRepoLanguageData(login, exclude, token, excludeRepos);
     return getOrganizationReposPerLanguageSVG(langData, themeName, override);
 };
 
@@ -39,8 +41,13 @@ const getOrganizationReposPerLanguageSVG = function (
     return svgString;
 };
 
-const getOrganizationRepoLanguageData = async function (login: string, exclude: Array<string>, token: string) {
-    const repoLanguages = await getOrganizationRepoLanguages(login, exclude, token);
+const getOrganizationRepoLanguageData = async function (
+    login: string,
+    exclude: Array<string>,
+    token: string,
+    excludeRepos: Array<string> = []
+) {
+    const repoLanguages = await getOrganizationRepoLanguages(login, exclude, token, excludeRepos);
     let langData = [];
 
     // make a pie data

--- a/src/cards/repos-per-language-card.ts
+++ b/src/cards/repos-per-language-card.ts
@@ -7,9 +7,10 @@ export const createReposPerLanguageCard = async function (
     username: string,
     exclude: Array<string>,
     token: string,
-    options: CardGenerationOptions = {}
+    options: CardGenerationOptions = {},
+    excludeRepos: Array<string> = []
 ) {
-    const langData = await getRepoLanguageData(username, exclude, token);
+    const langData = await getRepoLanguageData(username, exclude, token, excludeRepos);
     // use 1- prefix for sort in preview
     writeThemedCards('1-repos-per-language', themeName => getReposPerLanguageSVG(langData, themeName), options);
 };
@@ -19,10 +20,11 @@ export const getReposPerLanguageSVGWithThemeName = async function (
     themeName: string,
     exclude: Array<string>,
     token: string,
-    override?: ThemeColorOverride
+    override?: ThemeColorOverride,
+    excludeRepos: Array<string> = []
 ) {
     if (!ThemeMap.has(themeName)) throw new Error('Theme does not exist');
-    const langData = await getRepoLanguageData(username, exclude, token);
+    const langData = await getRepoLanguageData(username, exclude, token, excludeRepos);
     return getReposPerLanguageSVG(langData, themeName, override);
 };
 
@@ -41,8 +43,13 @@ const getReposPerLanguageSVG = function (
     return svgString;
 };
 
-const getRepoLanguageData = async function (username: string, exclude: Array<string>, token: string) {
-    const repoLanguages = await getRepoLanguages(username, exclude, token);
+const getRepoLanguageData = async function (
+    username: string,
+    exclude: Array<string>,
+    token: string,
+    excludeRepos: Array<string> = []
+) {
+    const repoLanguages = await getRepoLanguages(username, exclude, token, excludeRepos);
     let langData = [];
 
     // make a pie data

--- a/src/github-api/commits-per-language.ts
+++ b/src/github-api/commits-per-language.ts
@@ -43,6 +43,8 @@ const fetcher = (token: string, variables: any) => {
           contributionsCollection {
             commitContributionsByRepository(maxRepositories: 100) {
               repository {
+                name
+                nameWithOwner
                 primaryLanguage {
                   name
                   color
@@ -65,7 +67,8 @@ const fetcher = (token: string, variables: any) => {
 export async function getCommitLanguage(
     username: string,
     exclude: Array<string>,
-    token: string
+    token: string,
+    excludeRepos: Array<string> = []
 ): Promise<CommitLanguages> {
     const commitLanguages = new CommitLanguages();
 
@@ -77,9 +80,17 @@ export async function getCommitLanguage(
 
     res.data.data.user.contributionsCollection.commitContributionsByRepository.forEach(
         (node: {
-            repository: {primaryLanguage: {name: string; color: string} | null};
+            repository: {name: string; nameWithOwner: string; primaryLanguage: {name: string; color: string} | null};
             contributions: {totalCount: number};
         }) => {
+            // Commit contributions can live in other owners' repos, so match the
+            // exclusion list against both `repo` and `owner/repo` forms.
+            if (
+                excludeRepos.includes((node.repository.name ?? '').toLowerCase()) ||
+                excludeRepos.includes((node.repository.nameWithOwner ?? '').toLowerCase())
+            ) {
+                return;
+            }
             if (node.repository.primaryLanguage == null) {
                 return;
             }

--- a/src/github-api/organization-commits-per-language.ts
+++ b/src/github-api/organization-commits-per-language.ts
@@ -24,6 +24,7 @@ const fetcher = (token: string, variables: any) => {
             repositories(first: $first, privacy: PUBLIC, isFork: false, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
               nodes {
                 name
+                nameWithOwner
                 primaryLanguage {
                   name
                   color
@@ -73,10 +74,14 @@ export async function getOrganizationCommitLanguage(
     org.repositories.nodes.forEach(
         (node: {
             name: string;
+            nameWithOwner: string;
             primaryLanguage: {name: string; color: string} | null;
             defaultBranchRef: {target: {history: {totalCount: number}}} | null;
         }) => {
-            if (excludeRepos.includes((node.name ?? '').toLowerCase())) {
+            if (
+                excludeRepos.includes((node.name ?? '').toLowerCase()) ||
+                excludeRepos.includes((node.nameWithOwner ?? '').toLowerCase())
+            ) {
                 return;
             }
             if (node.primaryLanguage == null || node.defaultBranchRef == null) {

--- a/src/github-api/organization-commits-per-language.ts
+++ b/src/github-api/organization-commits-per-language.ts
@@ -23,6 +23,7 @@ const fetcher = (token: string, variables: any) => {
           ... on Organization {
             repositories(first: $first, privacy: PUBLIC, isFork: false, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
               nodes {
+                name
                 primaryLanguage {
                   name
                   color
@@ -51,7 +52,8 @@ const fetcher = (token: string, variables: any) => {
 export async function getOrganizationCommitLanguage(
     login: string,
     exclude: Array<string>,
-    token: string
+    token: string,
+    excludeRepos: Array<string> = []
 ): Promise<CommitLanguages> {
     const commitLanguages = new CommitLanguages();
 
@@ -70,9 +72,13 @@ export async function getOrganizationCommitLanguage(
 
     org.repositories.nodes.forEach(
         (node: {
+            name: string;
             primaryLanguage: {name: string; color: string} | null;
             defaultBranchRef: {target: {history: {totalCount: number}}} | null;
         }) => {
+            if (excludeRepos.includes((node.name ?? '').toLowerCase())) {
+                return;
+            }
             if (node.primaryLanguage == null || node.defaultBranchRef == null) {
                 return;
             }

--- a/src/github-api/organization-repos-per-language.ts
+++ b/src/github-api/organization-repos-per-language.ts
@@ -15,6 +15,7 @@ const fetcher = (token: string, variables: any) => {
           ... on Organization {
             repositories(isFork: false, first: 100, after: $endCursor, privacy: PUBLIC, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
               nodes {
+                name
                 primaryLanguage {
                   name
                   color
@@ -38,12 +39,13 @@ const fetcher = (token: string, variables: any) => {
 export async function getOrganizationRepoLanguages(
     login: string,
     exclude: Array<string>,
-    token: string
+    token: string,
+    excludeRepos: Array<string> = []
 ): Promise<RepoLanguages> {
     // Vercel: top-100 by stars in one query. Action/CLI: paginate all. See the
     // note in the user repos-per-language module.
     const repoLanguages = new RepoLanguages();
-    const nodes: {primaryLanguage: {name: string; color: string} | null}[] = [];
+    const nodes: {name: string; primaryLanguage: {name: string; color: string} | null}[] = [];
     let cursor: string | null = null;
     let hasNextPage = true;
 
@@ -59,7 +61,8 @@ export async function getOrganizationRepoLanguages(
         hasNextPage = !process.env.VERCEL && !!owner.repositories.pageInfo?.hasNextPage;
     }
 
-    nodes.forEach((node: {primaryLanguage: {name: string; color: string} | null}) => {
+    nodes.forEach((node: {name: string; primaryLanguage: {name: string; color: string} | null}) => {
+        if (excludeRepos.includes((node.name ?? '').toLowerCase())) return;
         if (node.primaryLanguage) {
             const langName = node.primaryLanguage.name;
             const langColor = node.primaryLanguage.color;

--- a/src/github-api/organization-repos-per-language.ts
+++ b/src/github-api/organization-repos-per-language.ts
@@ -16,6 +16,7 @@ const fetcher = (token: string, variables: any) => {
             repositories(isFork: false, first: 100, after: $endCursor, privacy: PUBLIC, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
               nodes {
                 name
+                nameWithOwner
                 primaryLanguage {
                   name
                   color
@@ -45,7 +46,7 @@ export async function getOrganizationRepoLanguages(
     // Vercel: top-100 by stars in one query. Action/CLI: paginate all. See the
     // note in the user repos-per-language module.
     const repoLanguages = new RepoLanguages();
-    const nodes: {name: string; primaryLanguage: {name: string; color: string} | null}[] = [];
+    const nodes: {name: string; nameWithOwner: string; primaryLanguage: {name: string; color: string} | null}[] = [];
     let cursor: string | null = null;
     let hasNextPage = true;
 
@@ -61,16 +62,23 @@ export async function getOrganizationRepoLanguages(
         hasNextPage = !process.env.VERCEL && !!owner.repositories.pageInfo?.hasNextPage;
     }
 
-    nodes.forEach((node: {name: string; primaryLanguage: {name: string; color: string} | null}) => {
-        if (excludeRepos.includes((node.name ?? '').toLowerCase())) return;
-        if (node.primaryLanguage) {
-            const langName = node.primaryLanguage.name;
-            const langColor = node.primaryLanguage.color;
-            if (!exclude.includes(langName.toLowerCase())) {
-                repoLanguages.addLanguage(langName, langColor);
+    nodes.forEach(
+        (node: {name: string; nameWithOwner: string; primaryLanguage: {name: string; color: string} | null}) => {
+            if (
+                excludeRepos.includes((node.name ?? '').toLowerCase()) ||
+                excludeRepos.includes((node.nameWithOwner ?? '').toLowerCase())
+            ) {
+                return;
+            }
+            if (node.primaryLanguage) {
+                const langName = node.primaryLanguage.name;
+                const langColor = node.primaryLanguage.color;
+                if (!exclude.includes(langName.toLowerCase())) {
+                    repoLanguages.addLanguage(langName, langColor);
+                }
             }
         }
-    });
+    );
 
     return repoLanguages;
 }

--- a/src/github-api/repos-per-language.ts
+++ b/src/github-api/repos-per-language.ts
@@ -43,6 +43,7 @@ const fetcher = (token: string, variables: any) => {
         user(login: $login) {
           repositories(isFork: false, first: 100, after: $endCursor, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
             nodes {
+              name
               primaryLanguage {
                 name
                 color
@@ -65,13 +66,14 @@ const fetcher = (token: string, variables: any) => {
 export async function getRepoLanguages(
     username: string,
     exclude: Array<string>,
-    token: string
+    token: string,
+    excludeRepos: Array<string> = []
 ): Promise<RepoLanguages> {
     // On Vercel (shared token + 10s function timeout) take only the top 100 repos
     // by stars in a single query. Run as a GitHub Action / CLI (the user's own
     // token, no timeout) paginate through every repo for a complete count.
     const repoLanguages = new RepoLanguages();
-    const nodes: {primaryLanguage: {name: string; color: string} | null}[] = [];
+    const nodes: {name: string; primaryLanguage: {name: string; color: string} | null}[] = [];
     let cursor: string | null = null;
     let hasNextPage = true;
 
@@ -84,7 +86,8 @@ export async function getRepoLanguages(
         hasNextPage = !process.env.VERCEL && !!repos.pageInfo?.hasNextPage;
     }
 
-    nodes.forEach((node: {primaryLanguage: {name: string; color: string} | null}) => {
+    nodes.forEach((node: {name: string; primaryLanguage: {name: string; color: string} | null}) => {
+        if (excludeRepos.includes((node.name ?? '').toLowerCase())) return;
         if (node.primaryLanguage) {
             const langName = node.primaryLanguage.name;
             const langColor = node.primaryLanguage.color;

--- a/src/github-api/repos-per-language.ts
+++ b/src/github-api/repos-per-language.ts
@@ -44,6 +44,7 @@ const fetcher = (token: string, variables: any) => {
           repositories(isFork: false, first: 100, after: $endCursor, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
             nodes {
               name
+              nameWithOwner
               primaryLanguage {
                 name
                 color
@@ -73,7 +74,7 @@ export async function getRepoLanguages(
     // by stars in a single query. Run as a GitHub Action / CLI (the user's own
     // token, no timeout) paginate through every repo for a complete count.
     const repoLanguages = new RepoLanguages();
-    const nodes: {name: string; primaryLanguage: {name: string; color: string} | null}[] = [];
+    const nodes: {name: string; nameWithOwner: string; primaryLanguage: {name: string; color: string} | null}[] = [];
     let cursor: string | null = null;
     let hasNextPage = true;
 
@@ -86,16 +87,23 @@ export async function getRepoLanguages(
         hasNextPage = !process.env.VERCEL && !!repos.pageInfo?.hasNextPage;
     }
 
-    nodes.forEach((node: {name: string; primaryLanguage: {name: string; color: string} | null}) => {
-        if (excludeRepos.includes((node.name ?? '').toLowerCase())) return;
-        if (node.primaryLanguage) {
-            const langName = node.primaryLanguage.name;
-            const langColor = node.primaryLanguage.color;
-            if (!exclude.includes(langName.toLowerCase())) {
-                repoLanguages.addLanguage(langName, langColor);
+    nodes.forEach(
+        (node: {name: string; nameWithOwner: string; primaryLanguage: {name: string; color: string} | null}) => {
+            if (
+                excludeRepos.includes((node.name ?? '').toLowerCase()) ||
+                excludeRepos.includes((node.nameWithOwner ?? '').toLowerCase())
+            ) {
+                return;
+            }
+            if (node.primaryLanguage) {
+                const langName = node.primaryLanguage.name;
+                const langColor = node.primaryLanguage.color;
+                if (!exclude.includes(langName.toLowerCase())) {
+                    repoLanguages.addLanguage(langName, langColor);
+                }
             }
         }
-    });
+    );
 
     return repoLanguages;
 }

--- a/src/utils/owner-dispatch.ts
+++ b/src/utils/owner-dispatch.ts
@@ -55,11 +55,12 @@ export const dispatchReposPerLanguageSVG = function (
     themeName: string,
     exclude: Array<string>,
     token: string,
-    override?: ThemeColorOverride
+    override?: ThemeColorOverride,
+    excludeRepos: Array<string> = []
 ): Promise<string> {
     return dispatch(
-        () => getReposPerLanguageSVGWithThemeName(login, themeName, exclude, token, override),
-        () => getOrganizationReposPerLanguageSVGWithThemeName(login, themeName, exclude, token, override)
+        () => getReposPerLanguageSVGWithThemeName(login, themeName, exclude, token, override, excludeRepos),
+        () => getOrganizationReposPerLanguageSVGWithThemeName(login, themeName, exclude, token, override, excludeRepos)
     );
 };
 
@@ -68,11 +69,12 @@ export const dispatchMostCommitLanguageSVG = function (
     themeName: string,
     exclude: Array<string>,
     token: string,
-    override?: ThemeColorOverride
+    override?: ThemeColorOverride,
+    excludeRepos: Array<string> = []
 ): Promise<string> {
     return dispatch(
-        () => getCommitsLanguageSVGWithThemeName(login, themeName, exclude, token, override),
-        () => getOrganizationCommitsLanguageSVGWithThemeName(login, themeName, exclude, token, override)
+        () => getCommitsLanguageSVGWithThemeName(login, themeName, exclude, token, override, excludeRepos),
+        () => getOrganizationCommitsLanguageSVGWithThemeName(login, themeName, exclude, token, override, excludeRepos)
     );
 };
 

--- a/tests/github-api/commits-per-language.test.ts
+++ b/tests/github-api/commits-per-language.test.ts
@@ -109,4 +109,47 @@ describe('commit contributions on github', () => {
             ])
         });
     });
+
+    it('excludes repos by name or owner/name (case-insensitive)', async () => {
+        const dataWithRepoNames = {
+            data: {
+                user: {
+                    contributionsCollection: {
+                        commitContributionsByRepository: [
+                            {
+                                repository: {
+                                    name: 'My-App',
+                                    nameWithOwner: 'vn7n24fzkq/My-App',
+                                    primaryLanguage: {name: 'Rust', color: '#dea584'}
+                                },
+                                contributions: {totalCount: 99}
+                            },
+                            {
+                                repository: {
+                                    name: 'website',
+                                    nameWithOwner: 'someorg/website',
+                                    primaryLanguage: {name: 'JavaScript', color: '#f1e05a'}
+                                },
+                                contributions: {totalCount: 84}
+                            },
+                            {
+                                repository: {
+                                    name: 'keeper',
+                                    nameWithOwner: 'vn7n24fzkq/keeper',
+                                    primaryLanguage: {name: 'Kotlin', color: '#f18e33'}
+                                },
+                                contributions: {totalCount: 10}
+                            }
+                        ]
+                    }
+                }
+            }
+        };
+        mock.onPost('https://api.github.com/graphql').reply(200, dataWithRepoNames);
+        // 'my-app' matches by plain name; 'someorg/website' matches by owner/name.
+        const repoData = await getCommitLanguage('vn7n24fzkq', [], 'token', ['my-app', 'someorg/website']);
+        expect(repoData).toEqual({
+            languageMap: new Map([['Kotlin', {color: '#f18e33', count: 10, name: 'Kotlin'}]])
+        });
+    });
 });

--- a/tests/github-api/repos-per-language.test.ts
+++ b/tests/github-api/repos-per-language.test.ts
@@ -126,6 +126,28 @@ describe('repos per language on github', () => {
         });
     });
 
+    it('excludes repos by name (case-insensitive)', async () => {
+        const dataWithRepoNames = {
+            data: {
+                user: {
+                    repositories: {
+                        nodes: [
+                            {name: 'Dotfiles', primaryLanguage: {color: '#89e051', name: 'Shell'}},
+                            {name: 'my-app', primaryLanguage: {color: '#b07219', name: 'Java'}},
+                            {name: 'my-fork', primaryLanguage: {color: '#dea584', name: 'Rust'}}
+                        ],
+                        pageInfo: {endCursor: null, hasNextPage: false}
+                    }
+                }
+            }
+        };
+        mock.onPost('https://api.github.com/graphql').reply(200, dataWithRepoNames);
+        const repoData = await getRepoLanguages('vn7n24fzkq', [], 'token', ['dotfiles', 'my-fork']);
+        expect(repoData).toEqual({
+            languageMap: new Map([['Java', {color: '#b07219', count: 1, name: 'Java'}]])
+        });
+    });
+
     it('paginates through every page when not on Vercel (Action/CLI)', async () => {
         delete process.env.VERCEL;
         mock.onPost('https://api.github.com/graphql')

--- a/tests/github-api/repos-per-language.test.ts
+++ b/tests/github-api/repos-per-language.test.ts
@@ -132,9 +132,21 @@ describe('repos per language on github', () => {
                 user: {
                     repositories: {
                         nodes: [
-                            {name: 'Dotfiles', primaryLanguage: {color: '#89e051', name: 'Shell'}},
-                            {name: 'my-app', primaryLanguage: {color: '#b07219', name: 'Java'}},
-                            {name: 'my-fork', primaryLanguage: {color: '#dea584', name: 'Rust'}}
+                            {
+                                name: 'Dotfiles',
+                                nameWithOwner: 'vn7n24fzkq/Dotfiles',
+                                primaryLanguage: {color: '#89e051', name: 'Shell'}
+                            },
+                            {
+                                name: 'my-app',
+                                nameWithOwner: 'vn7n24fzkq/my-app',
+                                primaryLanguage: {color: '#b07219', name: 'Java'}
+                            },
+                            {
+                                name: 'my-fork',
+                                nameWithOwner: 'vn7n24fzkq/my-fork',
+                                primaryLanguage: {color: '#dea584', name: 'Rust'}
+                            }
                         ],
                         pageInfo: {endCursor: null, hasNextPage: false}
                     }
@@ -142,7 +154,8 @@ describe('repos per language on github', () => {
             }
         };
         mock.onPost('https://api.github.com/graphql').reply(200, dataWithRepoNames);
-        const repoData = await getRepoLanguages('vn7n24fzkq', [], 'token', ['dotfiles', 'my-fork']);
+        // one plain name, one owner/repo form — both must match
+        const repoData = await getRepoLanguages('vn7n24fzkq', [], 'token', ['dotfiles', 'vn7n24fzkq/my-fork']);
         expect(repoData).toEqual({
             languageMap: new Map([['Java', {color: '#b07219', count: 1, name: 'Java'}]])
         });


### PR DESCRIPTION
Adds repository exclusion to both language cards, for the web API and the GitHub Action.

**Web API** — `exclude_repos` query param (comma-separated, case-insensitive):
```
/api/cards/repos-per-language?username=me&exclude_repos=dotfiles,my-fork
/api/cards/most-commit-language?username=me&exclude_repos=someorg/website
```
On the commits card, `owner/repo` entries also match — commit contributions can come from other owners' repositories.

**GitHub Action** — new `EXCLUDE_REPOS` input with the same semantics.

- Threaded through user + organization variants of both cards
- GraphQL queries now fetch repo `name` (and `nameWithOwner` for commits)
- Documented in README and `action.yml`, covered by unit tests

Closes #198
Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added repository-level exclusions to repos-per-language and most-commit-language cards (including organization variants) via a new `exclude_repos` query parameter / `EXCLUDE_REPOS` action input.
  * Supports comma-separated values, case-insensitive matching, and `owner/repo` matching for most-commit-language.
* **Documentation**
  * Updated API/action documentation for `exclude_repos`, including the `owner/repo` behavior.
* **Tests**
  * Added Jest coverage to verify exclusions work case-insensitively for both plain repo names and `owner/repo` forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->