### PR TITLE
fix: paginate repo data on Vercel for accurate star counts and language stats

### DIFF
--- a/src/const/pagination.ts
+++ b/src/const/pagination.ts
@@ -1,0 +1,20 @@
+// Repo pagination policy. Off Vercel (Action / CLI — the user's own token, no
+// duration limit) pagination is unbounded. On Vercel we used to stop at the
+// first 100 repos, which made star counts and language stats visibly wrong for
+// accounts with more repos (#164, #207, #182); instead, allow a bounded number
+// of pages: 10 pages = 1,000 repos covers practically every account while
+// keeping worst-case latency and GraphQL quota cost per render bounded.
+export const VERCEL_MAX_REPO_PAGES = 10;
+
+/**
+ * Decides whether another repository page should be fetched.
+ *
+ * @param {boolean} hasNextPage - Whether the API reports more pages.
+ * @param {number} pagesFetched - How many pages have been fetched so far.
+ * @return {boolean} True when the caller should fetch the next page.
+ */
+export function shouldFetchNextPage(hasNextPage: boolean, pagesFetched: number): boolean {
+    if (!hasNextPage) return false;
+    if (!process.env.VERCEL) return true;
+    return pagesFetched < VERCEL_MAX_REPO_PAGES;
+}

--- a/src/github-api/organization-details.ts
+++ b/src/github-api/organization-details.ts
@@ -1,4 +1,5 @@
 import request, {assertNoGraphQLErrors} from '../utils/request';
+import {shouldFetchNextPage} from '../const/pagination';
 
 export class OrganizationDetails {
     id: number;
@@ -83,6 +84,7 @@ export async function getOrganizationDetails(login: string, token: string): Prom
     let organizationDetails: OrganizationDetails | null = null;
     let cursor: string | null = null;
     let hasNextPage = true;
+    let pages = 0;
 
     while (hasNextPage) {
         const res: any = await fetcher(token, {login: login, endCursor: cursor});
@@ -114,7 +116,8 @@ export async function getOrganizationDetails(login: string, token: string): Prom
         }
 
         cursor = org.repositories.pageInfo?.endCursor ?? null;
-        hasNextPage = !process.env.VERCEL && !!org.repositories.pageInfo?.hasNextPage;
+        pages += 1;
+        hasNextPage = shouldFetchNextPage(!!org.repositories.pageInfo?.hasNextPage, pages);
     }
 
     return organizationDetails!;

--- a/src/github-api/organization-repos-per-language.ts
+++ b/src/github-api/organization-repos-per-language.ts
@@ -1,4 +1,5 @@
 import request, {assertNoGraphQLErrors} from '../utils/request';
+import {shouldFetchNextPage} from '../const/pagination';
 import {RepoLanguages} from './repos-per-language';
 
 const fetcher = (token: string, variables: any) => {
@@ -40,12 +41,12 @@ export async function getOrganizationRepoLanguages(
     exclude: Array<string>,
     token: string
 ): Promise<RepoLanguages> {
-    // Vercel: top-100 by stars in one query. Action/CLI: paginate all. See the
-    // note in the user repos-per-language module.
+    // Bounded pagination on Vercel, unbounded off it (see src/const/pagination.ts).
     const repoLanguages = new RepoLanguages();
     const nodes: {primaryLanguage: {name: string; color: string} | null}[] = [];
     let cursor: string | null = null;
     let hasNextPage = true;
+    let pages = 0;
 
     while (hasNextPage) {
         const res: any = await fetcher(token, {login: login, endCursor: cursor});
@@ -56,7 +57,8 @@ export async function getOrganizationRepoLanguages(
         }
         nodes.push(...owner.repositories.nodes);
         cursor = owner.repositories.pageInfo?.endCursor ?? null;
-        hasNextPage = !process.env.VERCEL && !!owner.repositories.pageInfo?.hasNextPage;
+        pages += 1;
+        hasNextPage = shouldFetchNextPage(!!owner.repositories.pageInfo?.hasNextPage, pages);
     }
 
     nodes.forEach((node: {primaryLanguage: {name: string; color: string} | null}) => {

--- a/src/github-api/profile-details.ts
+++ b/src/github-api/profile-details.ts
@@ -1,4 +1,5 @@
 import request, {assertNoGraphQLErrors} from '../utils/request';
+import {shouldFetchNextPage} from '../const/pagination';
 
 export class ProfileDetails {
     id: number; // user id
@@ -59,6 +60,10 @@ const fetcher = (token: string, variables: any) => {
                   totalCount
                 }
               }
+              pageInfo {
+                endCursor
+                hasNextPage
+              }
             }
             contributionsCollection {
                 contributionCalendar {
@@ -89,6 +94,37 @@ const fetcher = (token: string, variables: any) => {
     );
 };
 
+// Lightweight follow-up query used only to finish the star count for accounts
+// with more than 100 repos — the heavy fields (contribution calendar etc.) all
+// come from the first page.
+const starsFetcher = (token: string, variables: any) => {
+    return request(
+        {
+            Authorization: `bearer ${token}`
+        },
+        {
+            query: `
+      query UserStars($login: String!, $endCursor: String!) {
+        user(login: $login) {
+            repositories(first: 100, after: $endCursor, privacy:PUBLIC, isFork: false, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
+              nodes {
+                stargazers {
+                  totalCount
+                }
+              }
+              pageInfo {
+                endCursor
+                hasNextPage
+              }
+            }
+        }
+      }
+      `,
+            variables
+        }
+    );
+};
+
 export async function getProfileDetails(username: string, token: string): Promise<ProfileDetails> {
     const res = await fetcher(token, {
         login: username
@@ -105,6 +141,25 @@ export async function getProfileDetails(username: string, token: string): Promis
         },
         0
     );
+
+    // The main query only covers the first 100 repos; accounts with more were
+    // undercounting stars (#164). Keep summing with the lightweight star-only
+    // query — unbounded off Vercel, bounded on it (see src/const/pagination.ts).
+    let starsCursor: string | null = user.repositories.pageInfo?.endCursor ?? null;
+    let starsPages = 1;
+    let starsHasNextPage = shouldFetchNextPage(!!user.repositories.pageInfo?.hasNextPage, starsPages);
+    while (starsHasNextPage && starsCursor) {
+        const starsRes: any = await starsFetcher(token, {login: username, endCursor: starsCursor});
+        assertNoGraphQLErrors(starsRes, 'GetProfileDetails failed');
+        const repos = starsRes.data.data.user.repositories;
+        profileDetails.totalStars += repos.nodes.reduce(
+            (stars: number, curr: {stargazers: {totalCount: number}}) => stars + curr.stargazers.totalCount,
+            0
+        );
+        starsCursor = repos.pageInfo?.endCursor ?? null;
+        starsPages += 1;
+        starsHasNextPage = shouldFetchNextPage(!!repos.pageInfo?.hasNextPage, starsPages);
+    }
     profileDetails.websiteUrl = user.websiteUrl;
     profileDetails.totalIssueContributions = user.issues.totalCount;
     profileDetails.totalPullRequestContributions = user.pullRequests.totalCount;

--- a/src/github-api/repos-per-language.ts
+++ b/src/github-api/repos-per-language.ts
@@ -1,4 +1,5 @@
 import request, {assertNoGraphQLErrors} from '../utils/request';
+import {shouldFetchNextPage} from '../const/pagination';
 
 export class RepoLanguageInfo {
     name: string;
@@ -67,13 +68,13 @@ export async function getRepoLanguages(
     exclude: Array<string>,
     token: string
 ): Promise<RepoLanguages> {
-    // On Vercel (shared token + 10s function timeout) take only the top 100 repos
-    // by stars in a single query. Run as a GitHub Action / CLI (the user's own
-    // token, no timeout) paginate through every repo for a complete count.
+    // Ordered by stars DESC; pagination is unbounded off Vercel and bounded to
+    // VERCEL_MAX_REPO_PAGES on Vercel (see src/const/pagination.ts).
     const repoLanguages = new RepoLanguages();
     const nodes: {primaryLanguage: {name: string; color: string} | null}[] = [];
     let cursor: string | null = null;
     let hasNextPage = true;
+    let pages = 0;
 
     while (hasNextPage) {
         const res: any = await fetcher(token, {login: username, endCursor: cursor});
@@ -81,7 +82,8 @@ export async function getRepoLanguages(
         const repos = res.data.data.user.repositories;
         nodes.push(...repos.nodes);
         cursor = repos.pageInfo?.endCursor ?? null;
-        hasNextPage = !process.env.VERCEL && !!repos.pageInfo?.hasNextPage;
+        pages += 1;
+        hasNextPage = shouldFetchNextPage(!!repos.pageInfo?.hasNextPage, pages);
     }
 
     nodes.forEach((node: {primaryLanguage: {name: string; color: string} | null}) => {

--- a/tests/github-api/profile-details.test.ts
+++ b/tests/github-api/profile-details.test.ts
@@ -107,4 +107,27 @@ describe('github api for profile details', () => {
         mock.onPost('https://api.github.com/graphql').reply(200, error);
         await expect(getProfileDetails('vn7n24fzkq', 'token')).rejects.toThrow('GitHub api failed');
     });
+
+    it('sums stars across every repo page, not just the first 100', async () => {
+        const page1 = JSON.parse(JSON.stringify(data));
+        page1.data.user.repositories.pageInfo = {endCursor: 'C1', hasNextPage: true};
+        const starsPage2 = {
+            data: {
+                user: {
+                    repositories: {
+                        nodes: [{stargazers: {totalCount: 7}}, {stargazers: {totalCount: 3}}],
+                        pageInfo: {endCursor: null, hasNextPage: false}
+                    }
+                }
+            }
+        };
+        mock.onPost('https://api.github.com/graphql')
+            .replyOnce(200, page1)
+            .onPost('https://api.github.com/graphql')
+            .replyOnce(200, starsPage2)
+            .onAny();
+        const profileDetails = await getProfileDetails('vn7n24fzkq', 'token');
+        // 110 + 20 from page 1, 7 + 3 from the follow-up star query
+        expect(profileDetails.totalStars).toBe(140);
+    });
 });

--- a/tests/github-api/repos-per-language.test.ts
+++ b/tests/github-api/repos-per-language.test.ts
@@ -1,4 +1,5 @@
 import {getRepoLanguages} from '../../src/github-api/repos-per-language';
+import {VERCEL_MAX_REPO_PAGES} from '../../src/const/pagination';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 const mock = new MockAdapter(axios);
@@ -138,7 +139,7 @@ describe('repos per language on github', () => {
         expect(repoData.getLanguageMap().has('Kotlin')).toBe(true);
     });
 
-    it('stops after the first page on Vercel', async () => {
+    it('paginates on Vercel too (accuracy fix)', async () => {
         process.env.VERCEL = '1';
         mock.onPost('https://api.github.com/graphql')
             .replyOnce(200, page1)
@@ -146,8 +147,32 @@ describe('repos per language on github', () => {
             .replyOnce(200, page2)
             .onAny();
         const repoData = await getRepoLanguages('vn7n24fzkq', [], 'token');
-        // only page 1 fetched → Kotlin (page 2) absent
-        expect(repoData.getLanguageMap().has('Kotlin')).toBe(false);
+        // page 2's Kotlin is included → Vercel no longer stops at 100 repos
+        expect(repoData.getLanguageMap().has('Kotlin')).toBe(true);
         expect(repoData.getLanguageMap().has('Java')).toBe(true);
+    });
+
+    it('caps pagination at VERCEL_MAX_REPO_PAGES on Vercel', async () => {
+        process.env.VERCEL = '1';
+        let requests = 0;
+        mock.onPost('https://api.github.com/graphql').reply(() => {
+            requests += 1;
+            // every page claims there is more data
+            return [
+                200,
+                {
+                    data: {
+                        user: {
+                            repositories: {
+                                nodes: [{name: `repo-${requests}`, primaryLanguage: {color: '#b07219', name: 'Java'}}],
+                                pageInfo: {endCursor: `C${requests}`, hasNextPage: true}
+                            }
+                        }
+                    }
+                }
+            ];
+        });
+        await getRepoLanguages('vn7n24fzkq', [], 'token');
+        expect(requests).toBe(VERCEL_MAX_REPO_PAGES);
     });
 });


### PR DESCRIPTION
Long-term fix for the "data is inaccurate on the hosted service" family of issues.

**Before:** the web service stopped at the top 100 repos by stars — star totals and language breakdowns were visibly wrong for accounts with more repos (`profile-details` never paginated at all, even in Action mode).

**After:**
- `profile-details` completes the star count with a lightweight star-only follow-up query when the account has >100 repos
- `repos-per-language` (user + org) and `organization-details` now paginate on Vercel too, bounded at **10 pages (1,000 repos)** via a shared `shouldFetchNextPage` policy; Action/CLI remains unbounded
- Accounts with ≤100 repos make exactly the same number of API calls as before, so the common case costs nothing extra

**Quota note:** worst case is +9 GraphQL points per cache-miss render of an affected card, against a 24h CDN cache and the doubled token pool.

Closes #164
Closes #207
Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile star totals now include repositories beyond the first 100.
  * Repository data and language statistics can be fetched across multiple pages.
  * Vercel requests are capped to improve reliability and prevent excessive loading.

* **Bug Fixes**
  * Corrected pagination handling so additional repository data is included when available.

* **Tests**
  * Added coverage for multi-page star totals and pagination limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->