### PR TITLE
fix: make EXCLUDE language matching case-insensitive in the GitHub Action

### DIFF
--- a/api/cards/most-commit-language.ts
+++ b/api/cards/most-commit-language.ts
@@ -1,6 +1,6 @@
 import {dispatchMostCommitLanguageSVG} from '../../src/utils/owner-dispatch';
 import {handleCard} from '../utils/handle-card';
-import {translateLanguage} from '../../src/utils/translator';
+import {parseExcludeLanguages} from '../../src/utils/translator';
 import type {VercelRequest, VercelResponse} from '@vercel/node';
 
 export default (req: VercelRequest, res: VercelResponse) => {
@@ -9,7 +9,7 @@ export default (req: VercelRequest, res: VercelResponse) => {
         res.status(400).send('exclude must be a string');
         return;
     }
-    const excludeArr = exclude.split(',').map(val => translateLanguage(val).toLowerCase());
+    const excludeArr = parseExcludeLanguages(exclude);
     return handleCard(req, res, 'most_commit_language_card', (username, theme, override, token) =>
         dispatchMostCommitLanguageSVG(username, theme, excludeArr, token, override)
     );

--- a/api/cards/repos-per-language.ts
+++ b/api/cards/repos-per-language.ts
@@ -1,6 +1,6 @@
 import {dispatchReposPerLanguageSVG} from '../../src/utils/owner-dispatch';
 import {handleCard} from '../utils/handle-card';
-import {translateLanguage} from '../../src/utils/translator';
+import {parseExcludeLanguages} from '../../src/utils/translator';
 import type {VercelRequest, VercelResponse} from '@vercel/node';
 
 export default (req: VercelRequest, res: VercelResponse) => {
@@ -9,7 +9,7 @@ export default (req: VercelRequest, res: VercelResponse) => {
         res.status(400).send('exclude must be a string');
         return;
     }
-    const excludeArr = exclude.split(',').map(val => translateLanguage(val).toLowerCase());
+    const excludeArr = parseExcludeLanguages(exclude);
     return handleCard(req, res, 'repos_per_language_card', (username, theme, override, token) =>
         dispatchReposPerLanguageSVG(username, theme, excludeArr, token, override)
     );

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,7 +11,7 @@ import {createOrganizationCommitsPerLanguageCard} from './cards/organization-mos
 import {createOrganizationStatsCard} from './cards/organization-stats-card';
 import {getOwnerType, OwnerType} from './github-api/owner-type';
 import {spawn} from 'child_process';
-import {translateLanguage} from './utils/translator';
+import {parseExcludeLanguages} from './utils/translator';
 import {OUTPUT_PATH, generatePreviewMarkdown} from './utils/file-writer';
 import {ThemeMap} from './const/theme';
 import {parseAnimation} from './utils/animation';
@@ -147,7 +147,7 @@ const action = async () => {
     core.info(`Username: ${username}`);
     const utcOffset = Number(core.getInput('UTC_OFFSET', {required: false}));
     core.info(`UTC offset: ${utcOffset}`);
-    const exclude = core.getInput('EXCLUDE', {required: false}).split(',');
+    const exclude = parseExcludeLanguages(core.getInput('EXCLUDE', {required: false}));
     core.info(`Excluded languages: ${exclude}`);
     const autoPush = core.getBooleanInput('AUTO_PUSH', {required: false});
     core.info(`You ${autoPush ? 'have' : "haven't"} set automatically push commits`);
@@ -263,12 +263,6 @@ if (process.argv.length == 2) {
 } else {
     const username = process.argv[2];
     const utcOffset = Number(process.argv[3]);
-    const exclude: Array<string> = [];
-    if (process.argv[4]) {
-        process.argv[4].split(',').forEach(function (val) {
-            const translatedLanguage = translateLanguage(val);
-            exclude.push(translatedLanguage.toLowerCase());
-        });
-    }
+    const exclude = parseExcludeLanguages(process.argv[4] ?? '');
     main(username, utcOffset, exclude);
 }

--- a/src/utils/translator.ts
+++ b/src/utils/translator.ts
@@ -271,3 +271,13 @@ export const translateLanguage = function async(lang: string) {
     }
     return lang.charAt(0).toUpperCase() + lang.slice(1);
 };
+
+// Normalizes a comma separated EXCLUDE list into lowercase language names,
+// matching the lowercase comparison used by the language card filters.
+export const parseExcludeLanguages = function (input: string) {
+    return input
+        .split(',')
+        .map(val => val.trim())
+        .filter(val => val.length > 0)
+        .map(val => translateLanguage(val).toLowerCase());
+};

--- a/tests/utils/translator.test.ts
+++ b/tests/utils/translator.test.ts
@@ -1,0 +1,35 @@
+import {translateLanguage, parseExcludeLanguages} from '../../src/utils/translator';
+
+describe('translateLanguage', () => {
+    it('translates known aliases to the canonical language name', () => {
+        expect(translateLanguage('js')).toBe('JavaScript');
+        expect(translateLanguage('golang')).toBe('Go');
+        expect(translateLanguage('html')).toBe('HTML');
+    });
+
+    it('capitalizes unknown languages', () => {
+        expect(translateLanguage('java')).toBe('Java');
+        expect(translateLanguage('HTML')).toBe('HTML');
+    });
+});
+
+describe('parseExcludeLanguages', () => {
+    it('lowercases languages regardless of the input casing (#281)', () => {
+        expect(parseExcludeLanguages('HTML,CSS')).toEqual(['html', 'css']);
+        expect(parseExcludeLanguages('html,css')).toEqual(['html', 'css']);
+        expect(parseExcludeLanguages('Jupyter Notebook')).toEqual(['jupyter notebook']);
+    });
+
+    it('trims whitespace around entries', () => {
+        expect(parseExcludeLanguages('HTML, CSS , Java')).toEqual(['html', 'css', 'java']);
+    });
+
+    it('resolves aliases through translateLanguage', () => {
+        expect(parseExcludeLanguages('js,golang')).toEqual(['javascript', 'go']);
+    });
+
+    it('returns an empty list for empty input', () => {
+        expect(parseExcludeLanguages('')).toEqual([]);
+        expect(parseExcludeLanguages(' , ')).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #281.

The GitHub Action entry point passed `EXCLUDE` through with only a `split(',')`, while the language card filters compare **lowercase** names (`exclude.includes(langName.toLowerCase())`). So `EXCLUDE: "HTML,CSS"` produced `['HTML', 'CSS']` and silently matched nothing — the option only worked if the user happened to write it all-lowercase with no spaces. The CLI and Vercel API paths already normalized correctly, which is why only Action users hit this. Present since the feature was introduced in #97.

## Changes

- Add a shared `parseExcludeLanguages()` helper in `src/utils/translator.ts`: splits on commas, trims each entry, drops empties, resolves aliases via `translateLanguage()`, and lowercases the result.
- Use it in all three entry points: the Action path (the actual fix), the CLI path, and both Vercel API endpoints (behavior-preserving refactor, plus they now also tolerate spaces after commas).
- Add unit tests covering casing, whitespace, aliases, and empty input.

## Behavior after this change

| Input | Before | After |
|---|---|---|
| `EXCLUDE: "html,css"` | works | works (unchanged) |
| `EXCLUDE: "HTML,CSS"` | ignored | works |
| `EXCLUDE: "HTML, CSS"` | ignored | works |
| `EXCLUDE: "js,golang"` (aliases) | ignored in Action | works |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved language exclusion handling across generated cards, CLI usage, and GitHub Actions.
  - Exclusions now consistently support aliases, mixed capitalization, extra whitespace, and empty entries.
  - Empty or whitespace-only exclusion values are handled cleanly without affecting results.

- **Tests**
  - Added coverage for language alias conversion and exclusion-list normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->