### PR TITLE
feat: cache GitHub data in Upstash Redis, serve stale while rate limited

### DIFF
--- a/src/github-api/commits-per-language.ts
+++ b/src/github-api/commits-per-language.ts
@@ -1,4 +1,5 @@
 import request, {assertNoGraphQLErrors} from '../utils/request';
+import {withDataCache} from '../utils/data-cache';
 
 export class CommitLanguageInfo {
     name: string;
@@ -72,13 +73,18 @@ export async function getCommitLanguage(
 ): Promise<CommitLanguages> {
     const commitLanguages = new CommitLanguages();
 
-    const res = await fetcher(token, {
-        login: username
+    // Raw contribution list cached per username; filters apply after the cache.
+    const contributionsByRepository = await withDataCache(`v1:cl:${username.toLowerCase()}`, async () => {
+        const res = await fetcher(token, {
+            login: username
+        });
+
+        assertNoGraphQLErrors(res, 'GetCommitLanguage failed');
+
+        return res.data.data.user.contributionsCollection.commitContributionsByRepository;
     });
 
-    assertNoGraphQLErrors(res, 'GetCommitLanguage failed');
-
-    res.data.data.user.contributionsCollection.commitContributionsByRepository.forEach(
+    contributionsByRepository.forEach(
         (node: {
             repository: {name: string; nameWithOwner: string; primaryLanguage: {name: string; color: string} | null};
             contributions: {totalCount: number};

--- a/src/github-api/contributions-by-year.ts
+++ b/src/github-api/contributions-by-year.ts
@@ -1,4 +1,5 @@
 import request, {assertNoGraphQLErrors} from '../utils/request';
+import {withDataCache} from '../utils/data-cache';
 
 export class ConrtibutionByYear {
     year: number;
@@ -42,20 +43,27 @@ export async function getContributionByYear(
     year: number,
     token: string
 ): Promise<ConrtibutionByYear> {
-    const res = await fetcher(token, {
-        login: username,
-        from: year ? `${year}-01-01T00:00:00Z` : null,
-        to: year ? `${year}-12-31T23:59:59Z` : null
-    });
+    // Past years never change — cache them for much longer than the current one.
+    const isPastYear = !!year && year < new Date().getFullYear();
+    const raw = await withDataCache(
+        `v1:cy:${username.toLowerCase()}:${year}`,
+        async () => {
+            const res = await fetcher(token, {
+                login: username,
+                from: year ? `${year}-01-01T00:00:00Z` : null,
+                to: year ? `${year}-12-31T23:59:59Z` : null
+            });
 
-    assertNoGraphQLErrors(res, 'GetContributionByYear failed');
+            assertNoGraphQLErrors(res, 'GetContributionByYear failed');
 
-    const user = res.data.data.user;
-
-    const result = new ConrtibutionByYear(
-        year,
-        user.contributionsCollection.totalCommitContributions,
-        user.contributionsCollection.contributionCalendar.totalContributions
+            const user = res.data.data.user;
+            return {
+                totalCommitContributions: user.contributionsCollection.totalCommitContributions as number,
+                totalContributions: user.contributionsCollection.contributionCalendar.totalContributions as number
+            };
+        },
+        isPastYear ? 30 * 24 * 60 * 60 : undefined
     );
-    return result;
+
+    return new ConrtibutionByYear(year, raw.totalCommitContributions, raw.totalContributions);
 }

--- a/src/github-api/organization-commits-per-language.ts
+++ b/src/github-api/organization-commits-per-language.ts
@@ -5,6 +5,7 @@
 // time) and attribute it to that repo's primary language. `first: 1` is used
 // only to satisfy the connection arg — we read `totalCount`, not the nodes.
 import request, {assertNoGraphQLErrors} from '../utils/request';
+import {withDataCache} from '../utils/data-cache';
 import {CommitLanguages} from './commits-per-language';
 
 const MAX_REPOS = 50;
@@ -58,20 +59,23 @@ export async function getOrganizationCommitLanguage(
 ): Promise<CommitLanguages> {
     const commitLanguages = new CommitLanguages();
 
-    const res = await fetcher(token, {
-        login: login,
-        first: MAX_REPOS
+    // Raw node list cached per login; filters apply after the cache boundary.
+    const orgNodes = await withDataCache(`v1:ocl:${login.toLowerCase()}`, async () => {
+        const res = await fetcher(token, {
+            login: login,
+            first: MAX_REPOS
+        });
+
+        assertNoGraphQLErrors(res, 'GetOrganizationCommitLanguage failed');
+
+        const owner = res.data.data.repositoryOwner;
+        if (!owner || owner.__typename !== 'Organization') {
+            throw Error(`Organization not found: ${login}`);
+        }
+        return owner.repositories.nodes;
     });
 
-    assertNoGraphQLErrors(res, 'GetOrganizationCommitLanguage failed');
-
-    const owner = res.data.data.repositoryOwner;
-    if (!owner || owner.__typename !== 'Organization') {
-        throw Error(`Organization not found: ${login}`);
-    }
-    const org = owner;
-
-    org.repositories.nodes.forEach(
+    orgNodes.forEach(
         (node: {
             name: string;
             nameWithOwner: string;

--- a/src/github-api/organization-details.ts
+++ b/src/github-api/organization-details.ts
@@ -1,5 +1,6 @@
 import request, {assertNoGraphQLErrors} from '../utils/request';
 import {shouldFetchNextPage} from '../const/pagination';
+import {withDataCache} from '../utils/data-cache';
 
 export class OrganizationDetails {
     id: number;
@@ -81,44 +82,65 @@ export async function getOrganizationDetails(login: string, token: string): Prom
     // On Vercel (shared token + 10s timeout) fetch only the top 100 repos by stars
     // in one query. Run as a GitHub Action / CLI (own token, no timeout) paginate
     // every repo for accurate totals. totalPublicRepos is always exact (totalCount).
-    let organizationDetails: OrganizationDetails | null = null;
-    let cursor: string | null = null;
-    let hasNextPage = true;
-    let pages = 0;
+    // Raw org info + node list are cached per login; the OrganizationDetails
+    // instance (with real Date objects) is assembled after the cache boundary.
+    const {org, nodes} = await withDataCache(`v1:od:${login.toLowerCase()}`, async () => {
+        let orgInfo: any = null;
+        const collected: any[] = [];
+        let cursor: string | null = null;
+        let hasNextPage = true;
+        let pages = 0;
 
-    while (hasNextPage) {
-        const res: any = await fetcher(token, {login: login, endCursor: cursor});
+        while (hasNextPage) {
+            const res: any = await fetcher(token, {login: login, endCursor: cursor});
 
-        assertNoGraphQLErrors(res, 'GetOrganizationDetails failed');
+            assertNoGraphQLErrors(res, 'GetOrganizationDetails failed');
 
-        const owner = res.data.data.repositoryOwner;
-        if (!owner || owner.__typename !== 'Organization') {
-            throw Error(`Organization not found: ${login}`);
+            const owner = res.data.data.repositoryOwner;
+            if (!owner || owner.__typename !== 'Organization') {
+                throw Error(`Organization not found: ${login}`);
+            }
+
+            if (orgInfo === null) {
+                orgInfo = {
+                    id: owner.id,
+                    login: owner.login,
+                    name: owner.name,
+                    createdAt: owner.createdAt,
+                    description: owner.description,
+                    email: owner.email,
+                    location: owner.location,
+                    websiteUrl: owner.websiteUrl,
+                    twitterUsername: owner.twitterUsername,
+                    isVerified: owner.isVerified,
+                    totalPublicRepos: owner.repositories.totalCount
+                };
+            }
+            collected.push(...owner.repositories.nodes);
+
+            cursor = owner.repositories.pageInfo?.endCursor ?? null;
+            pages += 1;
+            hasNextPage = shouldFetchNextPage(!!owner.repositories.pageInfo?.hasNextPage, pages);
         }
-        const org = owner;
 
-        if (organizationDetails === null) {
-            organizationDetails = new OrganizationDetails(org.id, org.login, org.name, org.createdAt);
-            organizationDetails.description = org.description;
-            organizationDetails.email = org.email || null;
-            organizationDetails.location = org.location;
-            organizationDetails.websiteUrl = org.websiteUrl;
-            organizationDetails.twitterUsername = org.twitterUsername;
-            organizationDetails.isVerified = !!org.isVerified;
-            organizationDetails.totalPublicRepos = org.repositories.totalCount;
-        }
+        return {org: orgInfo, nodes: collected};
+    });
 
-        for (const node of org.repositories.nodes) {
-            organizationDetails.totalStars += node.stargazers.totalCount;
-            organizationDetails.totalForks += node.forkCount;
-            organizationDetails.totalOpenIssues += node.issues.totalCount;
-            organizationDetails.repoCreatedAt.push(new Date(node.createdAt));
-        }
+    const organizationDetails = new OrganizationDetails(org.id, org.login, org.name, org.createdAt);
+    organizationDetails.description = org.description;
+    organizationDetails.email = org.email || null;
+    organizationDetails.location = org.location;
+    organizationDetails.websiteUrl = org.websiteUrl;
+    organizationDetails.twitterUsername = org.twitterUsername;
+    organizationDetails.isVerified = !!org.isVerified;
+    organizationDetails.totalPublicRepos = org.totalPublicRepos;
 
-        cursor = org.repositories.pageInfo?.endCursor ?? null;
-        pages += 1;
-        hasNextPage = shouldFetchNextPage(!!org.repositories.pageInfo?.hasNextPage, pages);
+    for (const node of nodes) {
+        organizationDetails.totalStars += node.stargazers.totalCount;
+        organizationDetails.totalForks += node.forkCount;
+        organizationDetails.totalOpenIssues += node.issues.totalCount;
+        organizationDetails.repoCreatedAt.push(new Date(node.createdAt));
     }
 
-    return organizationDetails!;
+    return organizationDetails;
 }

--- a/src/github-api/organization-repos-per-language.ts
+++ b/src/github-api/organization-repos-per-language.ts
@@ -1,5 +1,6 @@
 import request, {assertNoGraphQLErrors} from '../utils/request';
 import {shouldFetchNextPage} from '../const/pagination';
+import {withDataCache} from '../utils/data-cache';
 import {RepoLanguages} from './repos-per-language';
 
 const fetcher = (token: string, variables: any) => {
@@ -45,24 +46,32 @@ export async function getOrganizationRepoLanguages(
     excludeRepos: Array<string> = []
 ): Promise<RepoLanguages> {
     // Bounded pagination on Vercel, unbounded off it (see src/const/pagination.ts).
+    // Raw node list cached per login; filters apply after the cache boundary.
     const repoLanguages = new RepoLanguages();
-    const nodes: {name: string; nameWithOwner: string; primaryLanguage: {name: string; color: string} | null}[] = [];
-    let cursor: string | null = null;
-    let hasNextPage = true;
-    let pages = 0;
+    const nodes = await withDataCache(`v1:orl:${login.toLowerCase()}`, async () => {
+        const collected: {
+            name: string;
+            nameWithOwner: string;
+            primaryLanguage: {name: string; color: string} | null;
+        }[] = [];
+        let cursor: string | null = null;
+        let hasNextPage = true;
+        let pages = 0;
 
-    while (hasNextPage) {
-        const res: any = await fetcher(token, {login: login, endCursor: cursor});
-        assertNoGraphQLErrors(res, 'GetOrganizationRepoLanguage fail');
-        const owner = res.data.data.repositoryOwner;
-        if (!owner || owner.__typename !== 'Organization') {
-            throw Error(`Organization not found: ${login}`);
+        while (hasNextPage) {
+            const res: any = await fetcher(token, {login: login, endCursor: cursor});
+            assertNoGraphQLErrors(res, 'GetOrganizationRepoLanguage fail');
+            const owner = res.data.data.repositoryOwner;
+            if (!owner || owner.__typename !== 'Organization') {
+                throw Error(`Organization not found: ${login}`);
+            }
+            collected.push(...owner.repositories.nodes);
+            cursor = owner.repositories.pageInfo?.endCursor ?? null;
+            pages += 1;
+            hasNextPage = shouldFetchNextPage(!!owner.repositories.pageInfo?.hasNextPage, pages);
         }
-        nodes.push(...owner.repositories.nodes);
-        cursor = owner.repositories.pageInfo?.endCursor ?? null;
-        pages += 1;
-        hasNextPage = shouldFetchNextPage(!!owner.repositories.pageInfo?.hasNextPage, pages);
-    }
+        return collected;
+    });
 
     nodes.forEach(
         (node: {name: string; nameWithOwner: string; primaryLanguage: {name: string; color: string} | null}) => {

--- a/src/github-api/owner-type.ts
+++ b/src/github-api/owner-type.ts
@@ -1,4 +1,5 @@
 import request, {assertNoGraphQLErrors} from '../utils/request';
+import {withDataCache} from '../utils/data-cache';
 
 export type OwnerType = 'User' | 'Organization';
 
@@ -21,21 +22,28 @@ const fetcher = (token: string, variables: any) => {
 };
 
 export async function getOwnerType(login: string, token: string): Promise<OwnerType> {
-    const res = await fetcher(token, {
-        login: login
-    });
+    // An account's type practically never changes — cache it for a week.
+    return withDataCache(
+        `v1:ot:${login.toLowerCase()}`,
+        async () => {
+            const res = await fetcher(token, {
+                login: login
+            });
 
-    assertNoGraphQLErrors(res, 'GetOwnerType failed');
+            assertNoGraphQLErrors(res, 'GetOwnerType failed');
 
-    const owner = res.data.data.repositoryOwner;
-    if (!owner) {
-        throw Error(`Login not found: ${login}`);
-    }
+            const owner = res.data.data.repositoryOwner;
+            if (!owner) {
+                throw Error(`Login not found: ${login}`);
+            }
 
-    const typename = owner.__typename;
-    if (typename !== 'User' && typename !== 'Organization') {
-        throw Error(`Unsupported owner type for ${login}: ${typename}`);
-    }
+            const typename = owner.__typename;
+            if (typename !== 'User' && typename !== 'Organization') {
+                throw Error(`Unsupported owner type for ${login}: ${typename}`);
+            }
 
-    return typename;
+            return typename as OwnerType;
+        },
+        7 * 24 * 60 * 60
+    );
 }

--- a/src/github-api/productive-time.ts
+++ b/src/github-api/productive-time.ts
@@ -1,4 +1,5 @@
 import request, {assertNoGraphQLErrors} from '../utils/request';
+import {withDataCache} from '../utils/data-cache';
 
 export class ProfuctiveTime {
     productiveDate: Date[] = [];
@@ -75,38 +76,45 @@ export async function getProductiveTime(
     since: string,
     token: string
 ): Promise<ProfuctiveTime> {
-    const userIdResponse = await userIdFetcher(token, {
-        login: username
+    // The since/until window shifts with the current date, so it's part of the
+    // key — plain commit-date strings are cached, Date-like usage stays outside.
+    const committedDates = await withDataCache(`v1:pt:${username.toLowerCase()}:${since}:${until}`, async () => {
+        const userIdResponse = await userIdFetcher(token, {
+            login: username
+        });
+
+        if (userIdResponse.data.errors) {
+            throw Error(userIdResponse.data.errors[0].message || 'GetProductiveTime failed');
+        }
+
+        const userId = userIdResponse.data.data.user.id;
+        const res = await fetcher(token, {
+            login: username,
+            userId: userId,
+            until: until,
+            since: since
+        });
+
+        assertNoGraphQLErrors(res, 'GetProductiveTime failed');
+
+        const dates: Date[] = [];
+        res.data.data.user.contributionsCollection.commitContributionsByRepository.forEach(
+            (node: {
+                repository: {
+                    defaultBranchRef: {target: {history: {edges: any[]}}} | null;
+                };
+            }) => {
+                if (node.repository.defaultBranchRef != null) {
+                    node.repository.defaultBranchRef.target.history.edges.forEach(edge => {
+                        dates.push(edge.node.committedDate);
+                    });
+                }
+            }
+        );
+        return dates;
     });
-
-    if (userIdResponse.data.errors) {
-        throw Error(userIdResponse.data.errors[0].message || 'GetProductiveTime failed');
-    }
-
-    const userId = userIdResponse.data.data.user.id;
-    const res = await fetcher(token, {
-        login: username,
-        userId: userId,
-        until: until,
-        since: since
-    });
-
-    assertNoGraphQLErrors(res, 'GetProductiveTime failed');
 
     const productiveTime = new ProfuctiveTime();
-    res.data.data.user.contributionsCollection.commitContributionsByRepository.forEach(
-        (node: {
-            repository: {
-                defaultBranchRef: {target: {history: {edges: any[]}}} | null;
-            };
-        }) => {
-            if (node.repository.defaultBranchRef != null) {
-                node.repository.defaultBranchRef.target.history.edges.forEach(node => {
-                    productiveTime.addProductiveDate(node.node.committedDate);
-                });
-            }
-        }
-    );
-
+    committedDates.forEach(date => productiveTime.addProductiveDate(date));
     return productiveTime;
 }

--- a/src/github-api/profile-details.ts
+++ b/src/github-api/profile-details.ts
@@ -1,5 +1,6 @@
 import request, {assertNoGraphQLErrors} from '../utils/request';
 import {shouldFetchNextPage} from '../const/pagination';
+import {withDataCache} from '../utils/data-cache';
 
 export class ProfileDetails {
     id: number; // user id
@@ -126,40 +127,47 @@ const starsFetcher = (token: string, variables: any) => {
 };
 
 export async function getProfileDetails(username: string, token: string): Promise<ProfileDetails> {
-    const res = await fetcher(token, {
-        login: username
-    });
+    // Cache the raw user payload + the fully paginated star total per username.
+    // The ProfileDetails instance (with real Date objects) is built after the
+    // cache boundary so only plain JSON is ever stored.
+    const {user, totalStars} = await withDataCache(`v1:pd:${username.toLowerCase()}`, async () => {
+        const res = await fetcher(token, {
+            login: username
+        });
 
-    assertNoGraphQLErrors(res, 'GetProfileDetails failed');
+        assertNoGraphQLErrors(res, 'GetProfileDetails failed');
 
-    const user = res.data.data.user;
-    const profileDetails = new ProfileDetails(user.id, user.name, user.email, user.createdAt);
-    profileDetails.totalPublicRepos = user.repositories.totalCount;
-    profileDetails.totalStars = user.repositories.nodes.reduce(
-        (stars: number, curr: {stargazers: {totalCount: number}}) => {
-            return stars + curr.stargazers.totalCount;
-        },
-        0
-    );
-
-    // The main query only covers the first 100 repos; accounts with more were
-    // undercounting stars (#164). Keep summing with the lightweight star-only
-    // query — unbounded off Vercel, bounded on it (see src/const/pagination.ts).
-    let starsCursor: string | null = user.repositories.pageInfo?.endCursor ?? null;
-    let starsPages = 1;
-    let starsHasNextPage = shouldFetchNextPage(!!user.repositories.pageInfo?.hasNextPage, starsPages);
-    while (starsHasNextPage && starsCursor) {
-        const starsRes: any = await starsFetcher(token, {login: username, endCursor: starsCursor});
-        assertNoGraphQLErrors(starsRes, 'GetProfileDetails failed');
-        const repos = starsRes.data.data.user.repositories;
-        profileDetails.totalStars += repos.nodes.reduce(
-            (stars: number, curr: {stargazers: {totalCount: number}}) => stars + curr.stargazers.totalCount,
+        const fetchedUser = res.data.data.user;
+        let stars: number = fetchedUser.repositories.nodes.reduce(
+            (acc: number, curr: {stargazers: {totalCount: number}}) => acc + curr.stargazers.totalCount,
             0
         );
-        starsCursor = repos.pageInfo?.endCursor ?? null;
-        starsPages += 1;
-        starsHasNextPage = shouldFetchNextPage(!!repos.pageInfo?.hasNextPage, starsPages);
-    }
+
+        // The main query only covers the first 100 repos; accounts with more were
+        // undercounting stars (#164). Keep summing with the lightweight star-only
+        // query — unbounded off Vercel, bounded on it (see src/const/pagination.ts).
+        let starsCursor: string | null = fetchedUser.repositories.pageInfo?.endCursor ?? null;
+        let starsPages = 1;
+        let starsHasNextPage = shouldFetchNextPage(!!fetchedUser.repositories.pageInfo?.hasNextPage, starsPages);
+        while (starsHasNextPage && starsCursor) {
+            const starsRes: any = await starsFetcher(token, {login: username, endCursor: starsCursor});
+            assertNoGraphQLErrors(starsRes, 'GetProfileDetails failed');
+            const repos = starsRes.data.data.user.repositories;
+            stars += repos.nodes.reduce(
+                (acc: number, curr: {stargazers: {totalCount: number}}) => acc + curr.stargazers.totalCount,
+                0
+            );
+            starsCursor = repos.pageInfo?.endCursor ?? null;
+            starsPages += 1;
+            starsHasNextPage = shouldFetchNextPage(!!repos.pageInfo?.hasNextPage, starsPages);
+        }
+
+        return {user: fetchedUser, totalStars: stars};
+    });
+
+    const profileDetails = new ProfileDetails(user.id, user.name, user.email, user.createdAt);
+    profileDetails.totalPublicRepos = user.repositories.totalCount;
+    profileDetails.totalStars = totalStars;
     profileDetails.websiteUrl = user.websiteUrl;
     profileDetails.totalIssueContributions = user.issues.totalCount;
     profileDetails.totalPullRequestContributions = user.pullRequests.totalCount;

--- a/src/github-api/repos-per-language.ts
+++ b/src/github-api/repos-per-language.ts
@@ -1,5 +1,6 @@
 import request, {assertNoGraphQLErrors} from '../utils/request';
 import {shouldFetchNextPage} from '../const/pagination';
+import {withDataCache} from '../utils/data-cache';
 
 export class RepoLanguageInfo {
     name: string;
@@ -73,21 +74,30 @@ export async function getRepoLanguages(
 ): Promise<RepoLanguages> {
     // Ordered by stars DESC; pagination is unbounded off Vercel and bounded to
     // VERCEL_MAX_REPO_PAGES on Vercel (see src/const/pagination.ts).
+    // The raw node list is cached per username (filters apply after the cache
+    // boundary, so exclude lists don't fragment it).
     const repoLanguages = new RepoLanguages();
-    const nodes: {name: string; nameWithOwner: string; primaryLanguage: {name: string; color: string} | null}[] = [];
-    let cursor: string | null = null;
-    let hasNextPage = true;
-    let pages = 0;
+    const nodes = await withDataCache(`v1:rl:${username.toLowerCase()}`, async () => {
+        const collected: {
+            name: string;
+            nameWithOwner: string;
+            primaryLanguage: {name: string; color: string} | null;
+        }[] = [];
+        let cursor: string | null = null;
+        let hasNextPage = true;
+        let pages = 0;
 
-    while (hasNextPage) {
-        const res: any = await fetcher(token, {login: username, endCursor: cursor});
-        assertNoGraphQLErrors(res, 'GetRepoLanguage fail');
-        const repos = res.data.data.user.repositories;
-        nodes.push(...repos.nodes);
-        cursor = repos.pageInfo?.endCursor ?? null;
-        pages += 1;
-        hasNextPage = shouldFetchNextPage(!!repos.pageInfo?.hasNextPage, pages);
-    }
+        while (hasNextPage) {
+            const res: any = await fetcher(token, {login: username, endCursor: cursor});
+            assertNoGraphQLErrors(res, 'GetRepoLanguage fail');
+            const repos = res.data.data.user.repositories;
+            collected.push(...repos.nodes);
+            cursor = repos.pageInfo?.endCursor ?? null;
+            pages += 1;
+            hasNextPage = shouldFetchNextPage(!!repos.pageInfo?.hasNextPage, pages);
+        }
+        return collected;
+    });
 
     nodes.forEach(
         (node: {name: string; nameWithOwner: string; primaryLanguage: {name: string; color: string} | null}) => {

--- a/src/utils/data-cache.ts
+++ b/src/utils/data-cache.ts
@@ -1,0 +1,90 @@
+// Shared GitHub-data cache backed by Upstash Redis (Vercel Marketplace).
+//
+// Why: the Vercel CDN cache is keyed per deployment and per full URL, so every
+// deploy starts cold and every theme/color variation of the same card re-hits
+// the GitHub API. Caching the *raw data* per username collapses all of those
+// into one GitHub fetch, survives deployments, and lets us serve slightly
+// stale data instead of an error card while rate limited.
+//
+// Design constraints:
+// - Fail-open: when the KV env vars are missing (Action/CLI/tests) or Redis
+//   errors/times out, callers behave exactly as without the cache.
+// - Only cache plain-JSON payloads (raw API data), never class instances —
+//   aggregation into Maps/Dates happens after the cache boundary.
+
+const FRESH_SECONDS_DEFAULT = 6 * 60 * 60; // serve without re-fetching
+const STALE_SECONDS = 7 * 24 * 60 * 60; // keep as a rate-limit fallback
+const KV_TIMEOUT_MS = 1500; // never let a slow Redis block a card render
+
+interface Envelope<T> {
+    at: number; // epoch ms when the data was fetched
+    data: T;
+}
+
+function kvConfigured(): boolean {
+    return !!process.env.KV_REST_API_URL && !!process.env.KV_REST_API_TOKEN;
+}
+
+async function kvGet<T>(key: string): Promise<Envelope<T> | null> {
+    try {
+        const res = await fetch(`${process.env.KV_REST_API_URL}/get/${encodeURIComponent(key)}`, {
+            headers: {Authorization: `Bearer ${process.env.KV_REST_API_TOKEN}`},
+            signal: AbortSignal.timeout(KV_TIMEOUT_MS)
+        });
+        if (!res.ok) return null;
+        const body = await res.json();
+        if (typeof body?.result !== 'string') return null;
+        return JSON.parse(body.result) as Envelope<T>;
+    } catch (e) {
+        return null;
+    }
+}
+
+async function kvSet<T>(key: string, envelope: Envelope<T>): Promise<void> {
+    try {
+        await fetch(`${process.env.KV_REST_API_URL}/set/${encodeURIComponent(key)}?EX=${STALE_SECONDS}`, {
+            method: 'POST',
+            headers: {Authorization: `Bearer ${process.env.KV_REST_API_TOKEN}`},
+            body: JSON.stringify(envelope),
+            signal: AbortSignal.timeout(KV_TIMEOUT_MS)
+        });
+    } catch (e) {
+        // Best-effort write; the card was already rendered from fresh data.
+    }
+}
+
+/**
+ * Returns cached data for `key` when fresh; otherwise runs `fetcher` and
+ * caches the result. When `fetcher` fails (e.g. GitHub rate limit) and a stale
+ * copy exists, the stale copy is served instead of failing the card.
+ *
+ * @param {string} key - Cache key; include every input that changes the data (never the token).
+ * @param {Function} fetcher - Fetches the raw, JSON-serialisable data.
+ * @param {number} [freshSeconds] - How long a cached copy is served without re-fetching.
+ * @return {Promise<T>} The fresh or cached data.
+ */
+export async function withDataCache<T>(
+    key: string,
+    fetcher: () => Promise<T>,
+    freshSeconds: number = FRESH_SECONDS_DEFAULT
+): Promise<T> {
+    if (!kvConfigured()) return fetcher();
+
+    const cached = await kvGet<T>(key);
+    if (cached && Date.now() - cached.at < freshSeconds * 1000) {
+        return cached.data;
+    }
+
+    try {
+        const data = await fetcher();
+        await kvSet(key, {at: Date.now(), data});
+        return data;
+    } catch (err) {
+        // Rate limited / GitHub down: a stale answer beats an error card.
+        if (cached) {
+            console.log(`data-cache: serving stale ${key} after fetch error: ${(err as Error)?.message}`);
+            return cached.data;
+        }
+        throw err;
+    }
+}

--- a/tests/utils/data-cache.test.ts
+++ b/tests/utils/data-cache.test.ts
@@ -1,0 +1,95 @@
+import {withDataCache} from '../../src/utils/data-cache';
+
+const KV_URL = 'https://fake-kv.upstash.io';
+
+function envelopeResponse(at: number, data: unknown) {
+    return {
+        ok: true,
+        json: async () => ({result: JSON.stringify({at, data})})
+    } as Response;
+}
+
+const missResponse = {
+    ok: true,
+    json: async () => ({result: null})
+} as Response;
+
+describe('withDataCache', () => {
+    let fetchSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        process.env.KV_REST_API_URL = KV_URL;
+        process.env.KV_REST_API_TOKEN = 'kv-token';
+        fetchSpy = jest.spyOn(global, 'fetch');
+    });
+
+    afterEach(() => {
+        fetchSpy.mockRestore();
+        delete process.env.KV_REST_API_URL;
+        delete process.env.KV_REST_API_TOKEN;
+    });
+
+    it('fails open when KV is not configured', async () => {
+        delete process.env.KV_REST_API_URL;
+        const fetcher = jest.fn().mockResolvedValue('fresh');
+        await expect(withDataCache('k', fetcher)).resolves.toBe('fresh');
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns the cached value without fetching when fresh', async () => {
+        fetchSpy.mockResolvedValueOnce(envelopeResponse(Date.now(), 'cached'));
+        const fetcher = jest.fn();
+        await expect(withDataCache('k', fetcher)).resolves.toBe('cached');
+        expect(fetcher).not.toHaveBeenCalled();
+    });
+
+    it('fetches and stores on a cache miss', async () => {
+        fetchSpy
+            .mockResolvedValueOnce(missResponse)
+            .mockResolvedValueOnce({ok: true, json: async () => ({})} as Response);
+        const fetcher = jest.fn().mockResolvedValue({value: 42});
+        await expect(withDataCache('k', fetcher)).resolves.toEqual({value: 42});
+        expect(fetcher).toHaveBeenCalledTimes(1);
+        // second fetch call is the SET
+        expect(fetchSpy.mock.calls[1][0]).toContain('/set/');
+    });
+
+    it('re-fetches when the cached value is stale', async () => {
+        const staleAt = Date.now() - 7 * 60 * 60 * 1000; // older than the 6h fresh window
+        fetchSpy
+            .mockResolvedValueOnce(envelopeResponse(staleAt, 'stale'))
+            .mockResolvedValueOnce({ok: true, json: async () => ({})} as Response);
+        const fetcher = jest.fn().mockResolvedValue('fresh');
+        await expect(withDataCache('k', fetcher)).resolves.toBe('fresh');
+    });
+
+    it('serves the stale value when the fetcher fails (rate limited)', async () => {
+        const staleAt = Date.now() - 7 * 60 * 60 * 1000;
+        fetchSpy.mockResolvedValueOnce(envelopeResponse(staleAt, 'stale'));
+        const fetcher = jest.fn().mockRejectedValue(new Error('rate limited'));
+        await expect(withDataCache('k', fetcher)).resolves.toBe('stale');
+    });
+
+    it('rethrows the fetcher error when there is no cached copy', async () => {
+        fetchSpy.mockResolvedValueOnce(missResponse);
+        const fetcher = jest.fn().mockRejectedValue(new Error('boom'));
+        await expect(withDataCache('k', fetcher)).rejects.toThrow('boom');
+    });
+
+    it('fails open when the KV read itself blows up', async () => {
+        fetchSpy.mockRejectedValueOnce(new Error('kv down')).mockRejectedValueOnce(new Error('kv down'));
+        const fetcher = jest.fn().mockResolvedValue('fresh');
+        await expect(withDataCache('k', fetcher)).resolves.toBe('fresh');
+    });
+
+    it('respects a custom fresh window', async () => {
+        const at = Date.now() - 60 * 1000; // 1 minute old
+        fetchSpy
+            .mockResolvedValueOnce(envelopeResponse(at, 'cached'))
+            .mockResolvedValueOnce({ok: true, json: async () => ({})} as Response);
+        const fetcher = jest.fn().mockResolvedValue('fresh');
+        // 30s fresh window → the 1-minute-old entry counts as stale
+        await expect(withDataCache('k', fetcher, 30)).resolves.toBe('fresh');
+        expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
Structural fix for the recurring rate-limit error cards.

**Problem:** the Vercel CDN cache is per-deployment and per-URL — every deploy starts cold, and every theme/color variation of the same card re-hits GitHub. Busy hours exhausted the GraphQL quota and cache-miss requests rendered error cards.

**Change:** a Redis-backed data cache (Upstash, provisioned via Vercel Marketplace) in front of every GitHub API module:

- Raw JSON is cached **per username** (`v1:` keys, 6h fresh / 7d stale). Filters (`exclude`, `exclude_repos`) and class/Date assembly happen *after* the cache boundary, so theme, color, animation and exclude variations all share one GitHub fetch.
- **Serve-stale-on-error:** while rate limited, a previously-seen card renders from the stale copy instead of an error card.
- **Fail-open everywhere:** no KV env (GitHub Action, CLI, tests) or any Redis error/timeout (1.5s cap) → exact pre-cache behaviour.
- Past contribution years cache 30d (immutable), owner type 7d, everything else 6h.

Expected effect: 80–95% fewer GitHub API calls from the web service, and deploys no longer cause a cold-start quota stampede.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added caching for GitHub data used across profile, contribution, repository, organization, language, and productivity views.
  * Cached results can improve loading times and reduce repeated requests.
  * Older cached data may be served when fresh data cannot be retrieved.

* **Bug Fixes**
  * Improved resilience when data services or cache storage are temporarily unavailable.

* **Tests**
  * Added coverage for cache hits, misses, expiration, fallback behavior, and configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->