### PR TITLE
docs: architecture documentation (mermaid)

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,58 @@
+# Architecture
+
+This project ships **two delivery modes from one codebase**:
+
+| Mode | Entry | Data freshness | Whose API quota | Repo coverage |
+|---|---|---|---|---|
+| **Web API** (Vercel) | `api/cards/*.ts` | CDN + Redis cached | Shared service tokens | Up to 1,000 repos (10 pages) |
+| **GitHub Action** | `dist/index.js` → `src/app.ts` | Regenerated per run | The user's own token | Unbounded |
+
+Both modes share the same core: `src/github-api/` (GraphQL fetchers), `src/cards/` (data → chart data), and `src/templates/` (d3 + jsdom SVG rendering).
+
+```mermaid
+flowchart TB
+    subgraph consumers[Consumers]
+        readme[GitHub README embeds via camo]
+        demo[Landing page /demo]
+        workflow[User's GitHub workflow]
+    end
+
+    subgraph vercel[Web API on Vercel]
+        cdn[CDN edge cache]
+        fn[Serverless functions api/cards/*]
+    end
+
+    subgraph action[GitHub Action]
+        dist[dist/index.js ncc bundle]
+        commit[Commit SVGs to user's repo]
+    end
+
+    subgraph shared[Shared core src/]
+        cards[src/cards data assembly]
+        templates[src/templates d3+jsdom SVG]
+        ghapi[src/github-api GraphQL fetchers]
+    end
+
+    redis[(Upstash Redis data cache)]
+    github[GitHub GraphQL API]
+
+    readme --> cdn
+    demo --> cdn
+    cdn -->|miss| fn
+    fn --> cards
+    workflow --> dist
+    dist --> cards
+    dist --> commit
+    cards --> templates
+    cards --> ghapi
+    ghapi -->|web only| redis
+    redis -->|miss / stale| github
+    ghapi -->|Action: direct| github
+```
+
+## Documents
+
+- [web-api.md](web-api.md) — Vercel request flow, token rotation, error handling
+- [github-action.md](github-action.md) — Action run flow and inputs
+- [caching.md](caching.md) — the two cache layers and quota strategy
+- [release-pipeline.md](release-pipeline.md) — branch model, CI, release and deploy

--- a/docs/architecture/caching.md
+++ b/docs/architecture/caching.md
@@ -1,0 +1,46 @@
+# Caching & quota strategy
+
+Two layers sit between viewers and the GitHub API. They exist because the
+hosted service runs on shared tokens: GitHub GraphQL allows **5,000 points per
+hour per account** (all tokens of one account share the pool — which is why the
+two service tokens belong to different accounts).
+
+```mermaid
+flowchart TB
+    viewer[Viewer] --> l1
+
+    subgraph l1[Layer 1 — Vercel CDN]
+        direction TB
+        l1note["Key: deployment + full URL<br/>fresh: s-maxage 24h<br/>stale-while-revalidate: 7d<br/>⚠ wiped on every deploy<br/>⚠ every theme/color combo is a separate key"]
+    end
+
+    subgraph l2[Layer 2 — Upstash Redis data cache]
+        direction TB
+        l2note["Key: v1:{kind}:{username}<br/>fresh: 6h (past years 30d, owner type 7d)<br/>stale kept: 7d → served on GitHub errors<br/>survives deployments<br/>all theme/color/exclude variations share one entry<br/>fail-open on any Redis error (1.5s timeout)"]
+    end
+
+    subgraph gh[GitHub GraphQL]
+        direction TB
+        ghnote["5,000 points/hr per account<br/>primary: machine account token<br/>fallback: owner PAT (rotation on 401/403/429)"]
+    end
+
+    l1 -->|miss| l2
+    l2 -->|miss or stale| gh
+```
+
+## What each layer protects against
+
+| Scenario | Before | Now |
+|---|---|---|
+| Same user, different theme/colors | Each combo hit GitHub | One Redis entry serves all combos |
+| New deployment | CDN cold → quota stampede | Redis is deployment-independent |
+| GitHub rate limited | Error card (cached 300s) | Stale data renders a normal card |
+| Redis outage / quota exhausted | — | Fail-open: behaves exactly like the pre-cache system |
+
+## Error-card caching
+
+Error cards are cached for **300s** (`public, max-age=300, s-maxage=300`) — long
+enough that repeat views don't burn quota during an incident, short enough to
+recover promptly. Successful cards use
+`public, max-age=14400, s-maxage=86400, stale-while-revalidate=604800`
+(`src/const/cache.ts`).

--- a/docs/architecture/github-action.md
+++ b/docs/architecture/github-action.md
@@ -1,0 +1,35 @@
+# GitHub Action
+
+Consumed as `vn7n24fzkq/github-profile-summary-cards@<tag>`. The tag points at
+the `release` branch state, which carries the ncc-bundled `dist/index.js`
+(built by the release workflow — `dist/` does not live on `main`). Runs on the
+`node24` Actions runtime.
+
+## Run flow
+
+```mermaid
+flowchart TB
+    trigger["User workflow: cron / push / dispatch"] --> inputs["Inputs: USERNAME, UTC_OFFSET, EXCLUDE, EXCLUDE_REPOS, THEME, ANIMATION, DURATION, NAME, AUTO_PUSH, BRANCH_NAME"]
+    inputs --> app["dist/index.js → src/app.ts action"]
+    app --> owner{getOwnerType}
+    owner -->|User| ucards["generateUserCards: profile-details, repos-per-language, most-commit-language, stats, productive-time"]
+    owner -->|Organization| ocards["generateOrganizationCards: org variants"]
+    ucards --> render["Render every theme, or the pinned THEME"]
+    ocards --> render
+    render --> files["Write SVGs to profile-summary-card-output/"]
+    files --> push{AUTO_PUSH?}
+    push -->|yes| commit["Commit & push to BRANCH_NAME, 3 retries"]
+    push -->|no| done[Leave files in workspace]
+```
+
+## Differences from the Web API
+
+| | GitHub Action | Web API |
+|---|---|---|
+| Token | User's own `GITHUB_TOKEN` secret | Shared service tokens |
+| Repo pagination | Unbounded (every repo) | Bounded at 10 pages / 1,000 repos |
+| Commit counts | All contribution years | Latest year only (labelled on the card) |
+| Redis cache | Not configured → `withDataCache` fails open, always fetches | 6h fresh / 7d stale |
+| Output | SVG files committed to the user's repo | SVG over HTTP |
+
+The Action needs `permissions: contents: write` to push the generated cards.

--- a/docs/architecture/release-pipeline.md
+++ b/docs/architecture/release-pipeline.md
@@ -1,0 +1,49 @@
+# Release pipeline
+
+One manual dispatch releases **both products** — the Vercel web API and the
+GitHub Action tag — from a single machine-managed `release` branch. See
+[`RELEASE.md`](../../RELEASE.md) for the operational runbook.
+
+## Branch model & flow
+
+```mermaid
+flowchart LR
+    feat[feature branch] -->|"PR: tests + lint required, squash"| main
+    main -->|every push| ci[CI + Vercel preview deploy]
+
+    subgraph rw[Manual Release workflow - dispatch with tag]
+        build["npm ci → build → ncc package dist/"]
+        recreate["Force-recreate release branch from main + dist/"]
+        tag["Tag + GitHub Release (previous_tag pinned)"]
+        build --> recreate --> tag
+    end
+
+    main --> build
+    recreate -->|push -f release| vercel[Vercel production deploy]
+    tag --> consumers["Action consumers pin @tag"]
+```
+
+## Guardrails & gotchas
+
+- **`main` ruleset**: PRs required, `tests` + `lint` must be green, no force
+  push; repo admin can bypass for emergency hotfixes.
+- **Release notes pin `previous_tag` explicitly** — `release` is
+  force-recreated every time, so GitHub's automatic previous-tag detection
+  walks back to ancient tags and every changelog looks identical.
+- **After a `vercel rollback`, auto-promotion is paused**: run
+  `vercel promote` on the new deployment after the next release.
+- **Every production deploy wipes the CDN cache** — the Redis data cache
+  absorbs the cold start.
+- **Vercel's runtime cannot `require()` ESM-only packages** even on Node 24
+  (caused the #275 outage) — verify dependency changes on a preview
+  deployment; local tests passing is not enough.
+
+## Environments
+
+| Environment | Branch | GitHub token | Notes |
+|---|---|---|---|
+| Production | `release` | Machine account (+ owner PAT fallback) | Domain: github-profile-summary-cards.vercel.app |
+| Preview | any push / PR | Owner PAT | Per-deployment URLs, protected by Vercel auth |
+| Development | local `vercel dev` | Owner PAT | `.env.local` (never committed) |
+
+Env-var changes only take effect on the **next deployment**.

--- a/docs/architecture/web-api.md
+++ b/docs/architecture/web-api.md
@@ -1,0 +1,66 @@
+# Web API (Vercel)
+
+Serverless functions under `api/cards/*.ts`, one per card. Production runs the
+`release` branch on Node.js 24 (`memory: 128`, `maxDuration: 10` in
+`vercel.json`).
+
+## Request flow
+
+```mermaid
+sequenceDiagram
+    participant V as Viewer (camo / demo / direct)
+    participant CDN as Vercel CDN
+    participant F as api/cards/*.ts
+    participant H as handleCard
+    participant D as owner-dispatch
+    participant C as withDataCache
+    participant R as Upstash Redis
+    participant G as GitHub GraphQL
+    participant GA as GA4
+
+    V->>CDN: GET /api/cards/stats?username=...&theme=...
+    alt CDN hit (per deployment + full URL)
+        CDN-->>V: cached SVG
+    else miss
+        CDN->>F: invoke function
+        F->>H: validate username / theme / params
+        H->>D: render via dispatch (user first, org fallback)
+        D->>C: github-api module fetch
+        alt Redis fresh (< 6h)
+            C->>R: GET v1:{kind}:{username}
+            R-->>C: raw JSON
+        else miss / stale
+            C->>G: GraphQL query (paginated, bounded to 10 pages)
+            G-->>C: raw data
+            C->>R: SET (7d retention)
+        end
+        C-->>D: raw data → filters → chart data
+        D-->>H: SVG (d3 + jsdom template, theme + color overrides + animation)
+        H-->>CDN: 200 image/svg+xml (max-age=14400, s-maxage=86400, SWR 7d)
+        CDN-->>V: SVG
+        H--)GA: waitUntil(sendAnalytics) after response
+    end
+```
+
+## Failure handling
+
+```mermaid
+flowchart TB
+    err[GitHub fetch fails] --> rot{401 / 403 / 429 / GraphQL RATE_LIMITED?}
+    rot -->|yes| next[Rotate to next token GITHUB_TOKEN_1]
+    next --> retry[Retry render]
+    retry -->|still failing| stale
+    rot -->|no| stale{Stale copy in Redis?}
+    stale -->|yes| serve[Serve stale data, render normal card]
+    stale -->|no| card[Generic error card, cached 300s]
+```
+
+Key points:
+
+- **Tokens**: `GITHUB_TOKEN` (machine account, production primary) →
+  `GITHUB_TOKEN_1` (owner PAT, fallback). Same-account tokens share one
+  quota pool, so the two tokens belong to different accounts.
+- **Error messages are sanitised** (`safeErrorMessage`) — raw GitHub errors can
+  leak the backing account and never reach the card.
+- **Analytics never block or fail a card**: fired with `waitUntil` after the
+  response; a bare fire-and-forget promise would be frozen with the lambda.


### PR DESCRIPTION
Adds `docs/architecture/` documenting the current system:

- **README.md** — system overview: two delivery modes sharing one core
- **web-api.md** — Vercel request flow (sequence diagram), token rotation, failure handling
- **github-action.md** — Action run flow and how it differs from the web API
- **caching.md** — CDN + Redis layers, TTLs, quota strategy
- **release-pipeline.md** — branch model, release workflow, guardrails and gotchas (previous_tag pinning, rollback promotion, ESM runtime limitation)

All diagrams are GitHub-rendered mermaid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architecture documentation covering the Web API and GitHub Action delivery modes.
  * Documented request flows, rendering, caching, quota protection, and error handling.
  * Added guidance for release workflows, deployment behavior, token configuration, and rollback safeguards.
  * Documented GitHub Action usage, triggers, generated SVG output, and required permissions.
  * Added an architecture overview with diagrams and links to related documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->