### PR TITLE
feat(analytics): username dimension, render leaderboard, error events, cache status

### DIFF
--- a/api/cards/most-commit-language.ts
+++ b/api/cards/most-commit-language.ts
@@ -18,7 +18,15 @@ export default (req: VercelRequest, res: VercelResponse) => {
     // Comma-separated repo names to skip (case-insensitive). Entries may be
     // `repo` or `owner/repo` — commit contributions can live in others' repos.
     const excludeReposArr = excludeReposRaw.split(',').map(val => val.trim().toLowerCase());
-    return handleCard(req, res, 'most_commit_language_card', (username, theme, override, token) =>
-        dispatchMostCommitLanguageSVG(username, theme, excludeArr, token, override, excludeReposArr)
+    return handleCard(
+        req,
+        res,
+        'most_commit_language_card',
+        (username, theme, override, token) =>
+            dispatchMostCommitLanguageSVG(username, theme, excludeArr, token, override, excludeReposArr),
+        {
+            exclude_used: String(exclude.length > 0),
+            exclude_repos_used: String(excludeReposRaw.length > 0)
+        }
     );
 };

--- a/api/cards/repos-per-language.ts
+++ b/api/cards/repos-per-language.ts
@@ -17,7 +17,15 @@ export default (req: VercelRequest, res: VercelResponse) => {
     const excludeArr = parseExcludeLanguages(exclude);
     // Comma-separated repo names to skip (case-insensitive), e.g. exclude_repos=dotfiles,my-fork
     const excludeReposArr = excludeReposRaw.split(',').map(val => val.trim().toLowerCase());
-    return handleCard(req, res, 'repos_per_language_card', (username, theme, override, token) =>
-        dispatchReposPerLanguageSVG(username, theme, excludeArr, token, override, excludeReposArr)
+    return handleCard(
+        req,
+        res,
+        'repos_per_language_card',
+        (username, theme, override, token) =>
+            dispatchReposPerLanguageSVG(username, theme, excludeArr, token, override, excludeReposArr),
+        {
+            exclude_used: String(exclude.length > 0),
+            exclude_repos_used: String(excludeReposRaw.length > 0)
+        }
     );
 };

--- a/api/cards/stats.ts
+++ b/api/cards/stats.ts
@@ -5,7 +5,11 @@ import type {VercelRequest, VercelResponse} from '@vercel/node';
 export default (req: VercelRequest, res: VercelResponse) => {
     // Opt-in flag to drop the big GitHub logo on the right of the stats card.
     const hideLogo = req.query.hide_logo === 'true';
-    return handleCard(req, res, 'stats_card', (username, theme, override, token) =>
-        dispatchStatsSVG(username, theme, token, override, hideLogo)
+    return handleCard(
+        req,
+        res,
+        'stats_card',
+        (username, theme, override, token) => dispatchStatsSVG(username, theme, token, override, hideLogo),
+        {hide_logo: String(hideLogo)}
     );
 };

--- a/api/pages/demo.html
+++ b/api/pages/demo.html
@@ -290,6 +290,27 @@
                 outline-offset: 2px;
             }
         </style>
+        <!-- GA4 page analytics. The measurement ID is public by design; the
+             Measurement Protocol api_secret stays server-side. Conservative
+             consent defaults: no ad storage/signals, only analytics.
+             No SRI hash: gtag.js is dynamically generated and updated by
+             Google, so a pinned integrity value would break on every rollout —
+             the accepted trade-off for Google-hosted tags. -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-MSMZVNK63E"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag() {
+                dataLayer.push(arguments);
+            }
+            gtag('consent', 'default', {
+                ad_storage: 'denied',
+                ad_user_data: 'denied',
+                ad_personalization: 'denied',
+                analytics_storage: 'granted'
+            });
+            gtag('js', new Date());
+            gtag('config', 'G-MSMZVNK63E');
+        </script>
     </head>
     <body>
         <div class="wrap">

--- a/api/utils/handle-card.ts
+++ b/api/utils/handle-card.ts
@@ -2,6 +2,7 @@ import {getGitHubToken} from './github-token-updater';
 import {getErrorMsgCard} from './error-card';
 import {waitUntil} from '@vercel/functions';
 import {sendAnalytics, resolveSource} from '../../src/utils/analytics';
+import {runWithCacheStats, bumpRenderLeaderboard} from '../../src/utils/data-cache';
 import {CONST_CACHE_CONTROL} from '../../src/const/cache';
 import {resolveThemeName, parseThemeColorOverride, ThemeColorOverride} from '../../src/const/theme';
 import {parseAnimation, applyAnimation} from '../../src/utils/animation';
@@ -26,25 +27,29 @@ function isRotatableError(err: any): boolean {
     return status === 401 || status === 403 || status === 429 || err?.isRateLimit === true;
 }
 
-// Map an internal error to a generic, user-facing message. The raw error (e.g.
-// "API rate limit already exceeded for user ID 20241522") can leak the backing
-// account/implementation, so it's logged server-side but never shown on the card
-// — the card only ever shows one of these safe, actionable messages.
-function safeErrorMessage(err: any): string {
+// Classify an internal error into a type (GA dimension) + a generic user-facing
+// message. The raw error (e.g. "API rate limit already exceeded for user ID
+// 20241522") can leak the backing account/implementation, so it's logged
+// server-side but never shown on the card — the card only ever shows one of
+// these safe, actionable messages.
+function classifyError(err: any): {type: string; message: string} {
     const raw = String(err?.message ?? '').toLowerCase();
     const status = err?.response?.status;
     // Rate limited: only on explicit evidence (429, our GraphQL isRateLimit flag, or
     // message text). Note 403 alone is NOT rate limiting — it's usually auth/permission.
     if (err?.isRateLimit === true || status === 429 || raw.includes('rate limit')) {
-        return 'Cards are temporarily rate limited. Please try again in a few minutes.';
+        return {
+            type: 'rate_limited',
+            message: 'Cards are temporarily rate limited. Please try again in a few minutes.'
+        };
     }
     // Not found: explicit 404, or GitHub's "could not resolve to a User/Organization".
     if (status === 404 || raw.includes('could not resolve') || raw.includes('not found') || raw.includes('not exist')) {
-        return 'Could not find that user or organization — please check the username.';
+        return {type: 'not_found', message: 'Could not find that user or organization — please check the username.'};
     }
     // Everything else (auth/permission incl. 401/403, token/config problems): stay
     // generic so we don't hint at the backing setup.
-    return 'This card is temporarily unavailable. Please try again later.';
+    return {type: 'unavailable', message: 'This card is temporarily unavailable. Please try again later.'};
 }
 
 // Shared request handler for every card endpoint: validates username/theme,
@@ -71,6 +76,8 @@ export async function handleCard(
     const override = parseThemeColorOverride(req.query);
     const animation = parseAnimation(req.query.animation);
 
+    const source = resolveSource(req.query.source, String(req.headers['user-agent'] ?? ''));
+
     try {
         let tokenIndex = 0;
         let token = getGitHubToken(tokenIndex);
@@ -78,17 +85,34 @@ export async function handleCard(
         // throws (no token at the next index).
         while (true) {
             try {
-                const cardSVG = await render(username, theme, override, token);
+                // Collect the data-cache outcome of this render so GA gets a
+                // cache_status dimension (fresh / miss / stale / mixed).
+                const {result: cardSVG, cacheStatus} = await runWithCacheStats(() =>
+                    render(username, theme, override, token)
+                );
                 res.setHeader('Content-Type', 'image/svg+xml');
                 res.setHeader('Cache-Control', CONST_CACHE_CONTROL);
                 res.send(applyAnimation(cardSVG, animation, req.query.duration));
                 // Don't block the response on analytics, but keep the invocation
-                // alive until the GA call settles — a bare `void` promise gets
+                // alive until the calls settle — a bare `void` promise gets
                 // frozen with the lambda after res.send and aborts on the next
                 // thaw. Tag the source (demo page vs README embed vs other) for
                 // GA segmentation.
-                const source = resolveSource(req.query.source, String(req.headers['user-agent'] ?? ''));
-                waitUntil(sendAnalytics(eventName, {username, theme, source, ...extraAnalytics}, req.headers));
+                waitUntil(
+                    sendAnalytics(
+                        eventName,
+                        {
+                            username,
+                            theme,
+                            source,
+                            cache_status: cacheStatus,
+                            animation: animation ?? 'none',
+                            ...extraAnalytics
+                        },
+                        req.headers
+                    )
+                );
+                waitUntil(bumpRenderLeaderboard(username));
                 return;
             } catch (err: any) {
                 console.log(err.message);
@@ -105,12 +129,18 @@ export async function handleCard(
         // Log only a redacted summary — never the raw error object, which for axios
         // failures carries the request config/headers (incl. the Authorization token)
         // and response body.
+        const {type: errorType, message} = classifyError(err);
         console.log(`card error [${eventName}] status=${err?.response?.status ?? 'n/a'}: ${err?.message ?? 'unknown'}`);
         res.setHeader('Content-Type', 'image/svg+xml');
         // Cache errors long enough that repeat views don't re-invoke the function
         // while we're rate limited (GitHub's GraphQL window is a full hour), but
         // short enough to recover promptly once the quota resets.
         res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300');
-        res.send(getErrorMsgCard(safeErrorMessage(err), theme));
+        res.send(getErrorMsgCard(message, theme));
+        // Errors used to be invisible in GA — report them with a type dimension
+        // so incidents (rate limits, token scope problems) show up immediately.
+        waitUntil(
+            sendAnalytics('card_error', {username, theme, source, card: eventName, error_type: errorType}, req.headers)
+        );
     }
 }

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -68,11 +68,14 @@ export async function sendAnalytics(
     // Wrap the entire body so fire-and-forget callers (`void sendAnalytics(...)`)
     // can never produce an unhandled rejection, even if setup throws before fetch.
     try {
-        // Destructure to remove sensitive PII (username) from the final payload.
-        // Bots aren't dropped here — the handler tags them `source=bot` (via
-        // resolveSource) so they stay visible in GA and can be filtered in reports.
+        // client_id stays a hash (stable "user" identity for GA), but the plain
+        // username is also sent as a card_username event param — GitHub logins
+        // are public, and this is what makes "which accounts get rendered most"
+        // reportable in GA. Bots aren't dropped here — the handler tags them
+        // `source=bot` (via resolveSource) so they can be filtered in reports.
         const {username, ...cleanParams} = params;
         const clientId = getClientId(username);
+        if (username) cleanParams.card_username = String(username).trim().toLowerCase();
 
         // Extract user IP + User-Agent from Vercel-injected headers
         // Vercel headers are plain objects (string | string[] | undefined)

--- a/src/utils/data-cache.ts
+++ b/src/utils/data-cache.ts
@@ -12,6 +12,8 @@
 // - Only cache plain-JSON payloads (raw API data), never class instances —
 //   aggregation into Maps/Dates happens after the cache boundary.
 
+import {AsyncLocalStorage} from 'async_hooks';
+
 const FRESH_SECONDS_DEFAULT = 6 * 60 * 60; // serve without re-fetching
 const STALE_SECONDS = 7 * 24 * 60 * 60; // keep as a rate-limit fallback
 const KV_TIMEOUT_MS = 1500; // never let a slow Redis block a card render
@@ -19,6 +21,43 @@ const KV_TIMEOUT_MS = 1500; // never let a slow Redis block a card render
 interface Envelope<T> {
     at: number; // epoch ms when the data was fetched
     data: T;
+}
+
+// Per-request cache-outcome collector. handleCard opens a context with
+// runWithCacheStats; every withDataCache call inside it records its outcome so
+// the request can report a cache_status analytics dimension. AsyncLocalStorage
+// keeps concurrent requests in the same lambda instance isolated.
+interface CacheStats {
+    fresh: number;
+    miss: number;
+    stale: number;
+}
+
+const cacheStatsStorage = new AsyncLocalStorage<CacheStats>();
+
+/**
+ * Runs `fn` with a fresh cache-outcome collector attached to the async context.
+ *
+ * @param {Function} fn - The request work (usually the card render).
+ * @return {Promise} Whatever `fn` resolves to, plus the collected stats.
+ */
+export async function runWithCacheStats<T>(fn: () => Promise<T>): Promise<{result: T; cacheStatus: string}> {
+    const stats: CacheStats = {fresh: 0, miss: 0, stale: 0};
+    const result = await cacheStatsStorage.run(stats, fn);
+    let cacheStatus = 'disabled';
+    if (kvConfigured()) {
+        if (stats.stale > 0) cacheStatus = 'stale';
+        else if (stats.miss > 0 && stats.fresh > 0) cacheStatus = 'mixed';
+        else if (stats.miss > 0) cacheStatus = 'miss';
+        else if (stats.fresh > 0) cacheStatus = 'fresh';
+        else cacheStatus = 'none';
+    }
+    return {result, cacheStatus};
+}
+
+function recordCacheOutcome(kind: keyof CacheStats): void {
+    const stats = cacheStatsStorage.getStore();
+    if (stats) stats[kind] += 1;
 }
 
 function kvConfigured(): boolean {
@@ -72,19 +111,52 @@ export async function withDataCache<T>(
 
     const cached = await kvGet<T>(key);
     if (cached && Date.now() - cached.at < freshSeconds * 1000) {
+        recordCacheOutcome('fresh');
         return cached.data;
     }
 
     try {
         const data = await fetcher();
         await kvSet(key, {at: Date.now(), data});
+        recordCacheOutcome('miss');
         return data;
     } catch (err) {
         // Rate limited / GitHub down: a stale answer beats an error card.
         if (cached) {
+            recordCacheOutcome('stale');
             console.log(`data-cache: serving stale ${key} after fetch error: ${(err as Error)?.message}`);
             return cached.data;
         }
         throw err;
+    }
+}
+
+/**
+ * Bumps the render leaderboards for a username: an all-time sorted set plus a
+ * monthly one (auto-expiring). Fire-and-forget, fail-open — a Redis hiccup
+ * never affects the card. View the boards in the Upstash data browser or GA.
+ *
+ * @param {string} username - The card subject (lowercased for aggregation).
+ * @return {Promise<void>} Resolves once the pipeline call settles.
+ */
+export async function bumpRenderLeaderboard(username: string): Promise<void> {
+    if (!kvConfigured()) return;
+    const user = username.toLowerCase();
+    const month = new Date().toISOString().slice(0, 7); // e.g. 2026-07
+    const monthlyKey = `leaderboard:renders:${month}`;
+    try {
+        await fetch(`${process.env.KV_REST_API_URL}/pipeline`, {
+            method: 'POST',
+            headers: {Authorization: `Bearer ${process.env.KV_REST_API_TOKEN}`},
+            body: JSON.stringify([
+                ['ZINCRBY', 'leaderboard:renders', '1', user],
+                ['ZINCRBY', monthlyKey, '1', user],
+                // Keep two months of monthly boards around, then let them expire.
+                ['EXPIRE', monthlyKey, String(62 * 24 * 60 * 60)]
+            ]),
+            signal: AbortSignal.timeout(KV_TIMEOUT_MS)
+        });
+    } catch (e) {
+        // Best-effort statistics; never let them fail a request.
     }
 }

--- a/tests/utils/analytics.test.ts
+++ b/tests/utils/analytics.test.ts
@@ -73,10 +73,26 @@ describe('Analytics Utils', () => {
 
         const event = body.events[0];
         expect(event.name).toBe('test_event');
-        expect(event.params.username).toBeUndefined(); // PII Removed
+        expect(event.params.username).toBeUndefined(); // raw param not forwarded
+        expect(event.params.card_username).toBe('testuser'); // reportable dimension
         expect(event.params.foo).toBe('bar');
         expect(event.params.session_id).toBeTruthy();
         expect(event.params.engagement_time_msec).toBe(100);
+    });
+
+    it('normalizes card_username and omits it when username is missing', async () => {
+        process.env.GA_MEASUREMENT_ID = 'G-TEST';
+        process.env.GA_API_SECRET = 'SECRET';
+        process.env.VERCEL = '1';
+        const {sendAnalytics} = require('../../src/utils/analytics');
+
+        await sendAnalytics('e', {username: '  Torvalds '});
+        let body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+        expect(body.events[0].params.card_username).toBe('torvalds');
+
+        await sendAnalytics('e', {});
+        body = JSON.parse((global.fetch as jest.Mock).mock.calls[1][1].body);
+        expect(body.events[0].params.card_username).toBeUndefined();
     });
 
     it('normalizes username casing/whitespace into the same client_id', async () => {

--- a/tests/utils/data-cache.test.ts
+++ b/tests/utils/data-cache.test.ts
@@ -1,4 +1,4 @@
-import {withDataCache} from '../../src/utils/data-cache';
+import {withDataCache, runWithCacheStats, bumpRenderLeaderboard} from '../../src/utils/data-cache';
 
 const KV_URL = 'https://fake-kv.upstash.io';
 
@@ -91,5 +91,96 @@ describe('withDataCache', () => {
         // 30s fresh window → the 1-minute-old entry counts as stale
         await expect(withDataCache('k', fetcher, 30)).resolves.toBe('fresh');
         expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('runWithCacheStats', () => {
+    let fetchSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        process.env.KV_REST_API_URL = KV_URL;
+        process.env.KV_REST_API_TOKEN = 'kv-token';
+        fetchSpy = jest.spyOn(global, 'fetch');
+    });
+
+    afterEach(() => {
+        fetchSpy.mockRestore();
+        delete process.env.KV_REST_API_URL;
+        delete process.env.KV_REST_API_TOKEN;
+    });
+
+    it('reports fresh when every lookup hit the cache', async () => {
+        fetchSpy.mockResolvedValue(envelopeResponse(Date.now(), 'cached'));
+        const {result, cacheStatus} = await runWithCacheStats(async () => {
+            await withDataCache('a', jest.fn());
+            await withDataCache('b', jest.fn());
+            return 'svg';
+        });
+        expect(result).toBe('svg');
+        expect(cacheStatus).toBe('fresh');
+    });
+
+    it('reports miss when data had to be fetched', async () => {
+        fetchSpy.mockResolvedValue(missResponse);
+        const {cacheStatus} = await runWithCacheStats(async () => {
+            await withDataCache('a', jest.fn().mockResolvedValue('x'));
+            return 'svg';
+        });
+        expect(cacheStatus).toBe('miss');
+    });
+
+    it('reports stale when a fallback copy was served', async () => {
+        const staleAt = Date.now() - 7 * 60 * 60 * 1000;
+        fetchSpy.mockResolvedValue(envelopeResponse(staleAt, 'stale'));
+        const {cacheStatus} = await runWithCacheStats(async () => {
+            await withDataCache('a', jest.fn().mockRejectedValue(new Error('rate limited')));
+            return 'svg';
+        });
+        expect(cacheStatus).toBe('stale');
+    });
+
+    it('reports disabled when KV is not configured', async () => {
+        delete process.env.KV_REST_API_URL;
+        const {cacheStatus} = await runWithCacheStats(async () => 'svg');
+        expect(cacheStatus).toBe('disabled');
+    });
+});
+
+describe('bumpRenderLeaderboard', () => {
+    let fetchSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        process.env.KV_REST_API_URL = KV_URL;
+        process.env.KV_REST_API_TOKEN = 'kv-token';
+        fetchSpy = jest.spyOn(global, 'fetch');
+    });
+
+    afterEach(() => {
+        fetchSpy.mockRestore();
+        delete process.env.KV_REST_API_URL;
+        delete process.env.KV_REST_API_TOKEN;
+    });
+
+    it('sends a pipeline with all-time and monthly ZINCRBY', async () => {
+        fetchSpy.mockResolvedValueOnce({ok: true, json: async () => []} as Response);
+        await bumpRenderLeaderboard('Torvalds');
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchSpy.mock.calls[0];
+        expect(String(url)).toContain('/pipeline');
+        const commands = JSON.parse(init.body);
+        expect(commands[0]).toEqual(['ZINCRBY', 'leaderboard:renders', '1', 'torvalds']);
+        expect(commands[1][0]).toBe('ZINCRBY');
+        expect(commands[1][1]).toMatch(/^leaderboard:renders:\d{4}-\d{2}$/);
+        expect(commands[2][0]).toBe('EXPIRE');
+    });
+
+    it('is a no-op without KV env and swallows Redis errors', async () => {
+        delete process.env.KV_REST_API_URL;
+        await expect(bumpRenderLeaderboard('a')).resolves.toBeUndefined();
+        expect(fetchSpy).not.toHaveBeenCalled();
+
+        process.env.KV_REST_API_URL = KV_URL;
+        fetchSpy.mockRejectedValueOnce(new Error('kv down'));
+        await expect(bumpRenderLeaderboard('a')).resolves.toBeUndefined();
     });
 });


### PR DESCRIPTION
Observability package for the web service.

## What's new in GA
| Param | Values | Answers |
|---|---|---|
| `card_username` | plain lowercased login | which accounts get rendered most |
| `card_error` event + `error_type` | rate_limited / not_found / unavailable | incidents visible in realtime |
| `cache_status` | fresh / miss / stale / mixed | Redis hit rate without extra tooling |
| `animation`, `hide_logo`, `exclude_used`, `exclude_repos_used` | strings | feature adoption |

`client_id` stays a hash (unchanged user semantics); GitHub logins are public info.

**GA4 setup needed once (Admin → Custom definitions → Create custom dimension, event scope):** register `card_username`, `source`, `cache_status`, `error_type`, `animation` to make them reportable.

## Redis leaderboards (no commands needed to view)
Every render does one pipelined `ZINCRBY` into `leaderboard:renders` (all-time) and `leaderboard:renders:YYYY-MM` (auto-expires after 62 days). View them sorted in **Vercel → Storage → Upstash → Data Browser**. Fail-open like the rest of the cache layer.

## Notes
- Numbers are **renders** (function invocations), not raw views — CDN hits never reach the function. True totals per endpoint live in Vercel Observability.
- `cache_status` is collected with `AsyncLocalStorage` so concurrent requests in one Fluid instance stay isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced card rendering analytics with normalized `card_username`, plus clearer, classified error reporting for better insights.
  * Added more detailed cache performance tracking (fresh/miss/stale/disabled) to card rendering outcomes.
  * Expanded filter/display option reporting used in analytics.
  * Enabled GA4 analytics on the demo page.
* **Bug Fixes**
  * Improved behavior when cache data is unavailable by retaining safe responses while recording cache outcomes.
* **Tests**
  * Updated and expanded analytics and cache test coverage for the new reporting fields and cache-status scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->