### PR TITLE
fix: avoid GitHub 502 on mega accounts, add pagination time budget

### DIFF
--- a/src/cards/productive-time-card.ts
+++ b/src/cards/productive-time-card.ts
@@ -63,9 +63,14 @@ const getProductiveTimeData = async function (
     utcOffset: number,
     token: string
 ): Promise<Array<number>> {
+    // Round the 1-year window to UTC day boundaries: the values feed the
+    // data-cache key, and millisecond-precision timestamps made the key unique
+    // per request — productive-time never cache-hit and littered Redis with
+    // throwaway keys. Day granularity costs <1 day of data on a 365-day window.
     const until = new Date();
-    const since = new Date();
-    since.setFullYear(since.getFullYear() - 1);
+    until.setUTCHours(24, 0, 0, 0); // end of the current UTC day
+    const since = new Date(until);
+    since.setUTCFullYear(since.getUTCFullYear() - 1);
     const productiveTime = await getProductiveTime(username, until.toISOString(), since.toISOString(), token);
     // process productiveTime
     const chartData = new Array(24);

--- a/src/const/pagination.ts
+++ b/src/const/pagination.ts
@@ -12,20 +12,31 @@ export const VERCEL_MAX_REPO_PAGES = 10;
 // 3 pages ≈ top 300 repos by stars renders in a few seconds.
 export const VERCEL_MAX_ORG_DETAIL_PAGES = 3;
 
+// Wall-clock budget for repo pagination on Vercel. Ordinary accounts fetch a
+// page in ~300ms and finish everything well inside it; mega accounts (1,000+
+// repos take ~3s/page GitHub-side) stop when the budget runs out and render
+// from the pages fetched so far — partial totals beat a 504, and the result
+// is cached for 6h anyway.
+export const VERCEL_PAGINATION_BUDGET_MS = 12000;
+
 /**
  * Decides whether another repository page should be fetched.
  *
  * @param {boolean} hasNextPage - Whether the API reports more pages.
  * @param {number} pagesFetched - How many pages have been fetched so far.
  * @param {number} [maxPages] - Vercel page budget for this query type.
+ * @param {number} [startedAtMs] - Pagination start time; on Vercel, stop once
+ *     VERCEL_PAGINATION_BUDGET_MS has elapsed even if pages remain.
  * @return {boolean} True when the caller should fetch the next page.
  */
 export function shouldFetchNextPage(
     hasNextPage: boolean,
     pagesFetched: number,
-    maxPages: number = VERCEL_MAX_REPO_PAGES
+    maxPages: number = VERCEL_MAX_REPO_PAGES,
+    startedAtMs?: number
 ): boolean {
     if (!hasNextPage) return false;
     if (!process.env.VERCEL) return true;
+    if (startedAtMs !== undefined && Date.now() - startedAtMs > VERCEL_PAGINATION_BUDGET_MS) return false;
     return pagesFetched < maxPages;
 }

--- a/src/github-api/profile-details.ts
+++ b/src/github-api/profile-details.ts
@@ -54,7 +54,7 @@ const fetcher = (token: string, variables: any) => {
             company
             location
             websiteUrl
-            repositories(first: 100,privacy:PUBLIC, isFork: false, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
+            repositories(first: 100,privacy:PUBLIC, isFork: false, ownerAffiliations: OWNER) {
               totalCount
               nodes {
                 stargazers {
@@ -107,7 +107,7 @@ const starsFetcher = (token: string, variables: any) => {
             query: `
       query UserStars($login: String!, $endCursor: String!) {
         user(login: $login) {
-            repositories(first: 100, after: $endCursor, privacy:PUBLIC, isFork: false, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
+            repositories(first: 100, after: $endCursor, privacy:PUBLIC, isFork: false, ownerAffiliations: OWNER) {
               nodes {
                 stargazers {
                   totalCount
@@ -146,9 +146,15 @@ export async function getProfileDetails(username: string, token: string): Promis
         // The main query only covers the first 100 repos; accounts with more were
         // undercounting stars (#164). Keep summing with the lightweight star-only
         // query — unbounded off Vercel, bounded on it (see src/const/pagination.ts).
+        const starsStartedAt = Date.now();
         let starsCursor: string | null = fetchedUser.repositories.pageInfo?.endCursor ?? null;
         let starsPages = 1;
-        let starsHasNextPage = shouldFetchNextPage(!!fetchedUser.repositories.pageInfo?.hasNextPage, starsPages);
+        let starsHasNextPage = shouldFetchNextPage(
+            !!fetchedUser.repositories.pageInfo?.hasNextPage,
+            starsPages,
+            undefined,
+            starsStartedAt
+        );
         while (starsHasNextPage && starsCursor) {
             const starsRes: any = await starsFetcher(token, {login: username, endCursor: starsCursor});
             assertNoGraphQLErrors(starsRes, 'GetProfileDetails failed');
@@ -159,7 +165,12 @@ export async function getProfileDetails(username: string, token: string): Promis
             );
             starsCursor = repos.pageInfo?.endCursor ?? null;
             starsPages += 1;
-            starsHasNextPage = shouldFetchNextPage(!!repos.pageInfo?.hasNextPage, starsPages);
+            starsHasNextPage = shouldFetchNextPage(
+                !!repos.pageInfo?.hasNextPage,
+                starsPages,
+                undefined,
+                starsStartedAt
+            );
         }
 
         return {user: fetchedUser, totalStars: stars};

--- a/src/github-api/repos-per-language.ts
+++ b/src/github-api/repos-per-language.ts
@@ -43,7 +43,7 @@ const fetcher = (token: string, variables: any) => {
             query: `
       query ReposPerLanguage($login: String!, $endCursor: String) {
         user(login: $login) {
-          repositories(isFork: false, first: 100, after: $endCursor, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
+          repositories(isFork: false, first: 100, after: $endCursor, ownerAffiliations: OWNER) {
             nodes {
               name
               nameWithOwner
@@ -83,6 +83,7 @@ export async function getRepoLanguages(
             nameWithOwner: string;
             primaryLanguage: {name: string; color: string} | null;
         }[] = [];
+        const startedAt = Date.now();
         let cursor: string | null = null;
         let hasNextPage = true;
         let pages = 0;
@@ -94,7 +95,7 @@ export async function getRepoLanguages(
             collected.push(...repos.nodes);
             cursor = repos.pageInfo?.endCursor ?? null;
             pages += 1;
-            hasNextPage = shouldFetchNextPage(!!repos.pageInfo?.hasNextPage, pages);
+            hasNextPage = shouldFetchNextPage(!!repos.pageInfo?.hasNextPage, pages, undefined, startedAt);
         }
         return collected;
     });

--- a/tests/const/pagination.test.ts
+++ b/tests/const/pagination.test.ts
@@ -1,0 +1,33 @@
+import {shouldFetchNextPage, VERCEL_MAX_REPO_PAGES, VERCEL_PAGINATION_BUDGET_MS} from '../../src/const/pagination';
+
+afterEach(() => {
+    delete process.env.VERCEL;
+});
+
+describe('shouldFetchNextPage', () => {
+    it('always continues off Vercel while pages remain', () => {
+        delete process.env.VERCEL;
+        expect(shouldFetchNextPage(true, 999)).toBe(true);
+        expect(shouldFetchNextPage(false, 1)).toBe(false);
+    });
+
+    it('caps pages on Vercel', () => {
+        process.env.VERCEL = '1';
+        expect(shouldFetchNextPage(true, VERCEL_MAX_REPO_PAGES - 1)).toBe(true);
+        expect(shouldFetchNextPage(true, VERCEL_MAX_REPO_PAGES)).toBe(false);
+    });
+
+    it('stops on Vercel when the time budget is spent, even with pages left', () => {
+        process.env.VERCEL = '1';
+        const exhausted = Date.now() - VERCEL_PAGINATION_BUDGET_MS - 1000;
+        expect(shouldFetchNextPage(true, 1, undefined, exhausted)).toBe(false);
+        // fresh budget → keeps going
+        expect(shouldFetchNextPage(true, 1, undefined, Date.now())).toBe(true);
+    });
+
+    it('ignores the budget off Vercel', () => {
+        delete process.env.VERCEL;
+        const exhausted = Date.now() - VERCEL_PAGINATION_BUDGET_MS - 1000;
+        expect(shouldFetchNextPage(true, 1, undefined, exhausted)).toBe(true);
+    });
+});


### PR DESCRIPTION
Production verification of v0.10.1 caught cards for **sindresorhus** (1,129 repos) consistently 504ing. Root cause isolated with direct GraphQL measurements:

- `repositories(orderBy: {field: STARGAZERS})` makes GitHub's executor **502** for 1,000+-repo accounts (10.9s then Bad Gateway, reproducible)
- retry-axios then retried the 502 until our function hit its 30s limit — and since the function was killed, nothing was ever cached, so these accounts could never succeed

## Fix
1. **User queries drop `orderBy: STARGAZERS`.** Star totals and language distributions are order-independent aggregations; for every account under ~1,000 repos unordered pagination fetches the identical full set. Natural order also happens to be ~3× cheaper for GitHub. Org queries keep the ordering (3-page sampling cap makes top-by-stars meaningful; orgs don't trip the 502).
2. **12s wall-clock pagination budget on Vercel** (`VERCEL_PAGINATION_BUDGET_MS`): ordinary accounts (~300ms/page) never notice; mega accounts (~3s/page GitHub-side) stop when the budget runs out and render partial-but-real totals instead of a 504 — then serve from Redis for 6h.

Measured on sindresorhus: natural-order pages ~3s each, so he lands ~4 star pages ≈ 500 repos within budget → renders in ~20s once, then <1s from cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safeguards to prevent repository pagination from exceeding configured page and time limits in hosted environments.

* **Bug Fixes**
  * Improved repository retrieval consistency by removing explicit result ordering.
  * Corrected productive-time reporting to use UTC day boundaries for its one-year analysis window.

* **Tests**
  * Added coverage for pagination limits, time budgets, and environment-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->