### PR TITLE
fix: drop star ordering from organization-details, add time budget

### DIFF
--- a/src/github-api/organization-details.ts
+++ b/src/github-api/organization-details.ts
@@ -52,7 +52,7 @@ const fetcher = (token: string, variables: any) => {
                 twitterUsername
                 createdAt
                 isVerified
-                repositories(first: 100, after: $endCursor, privacy: PUBLIC, isFork: false, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
+                repositories(first: 100, after: $endCursor, privacy: PUBLIC, isFork: false, ownerAffiliations: OWNER) {
                     totalCount
                     pageInfo {
                         endCursor
@@ -87,6 +87,7 @@ export async function getOrganizationDetails(login: string, token: string): Prom
     const {org, nodes} = await withDataCache(`v1:od:${login.toLowerCase()}`, async () => {
         let orgInfo: any = null;
         const collected: any[] = [];
+        const startedAt = Date.now();
         let cursor: string | null = null;
         let hasNextPage = true;
         let pages = 0;
@@ -123,7 +124,8 @@ export async function getOrganizationDetails(login: string, token: string): Prom
             hasNextPage = shouldFetchNextPage(
                 !!owner.repositories.pageInfo?.hasNextPage,
                 pages,
-                VERCEL_MAX_ORG_DETAIL_PAGES
+                VERCEL_MAX_ORG_DETAIL_PAGES,
+                startedAt
             );
         }
 

--- a/src/github-api/organization-details.ts
+++ b/src/github-api/organization-details.ts
@@ -79,9 +79,11 @@ const fetcher = (token: string, variables: any) => {
 };
 
 export async function getOrganizationDetails(login: string, token: string): Promise<OrganizationDetails> {
-    // On Vercel (shared token + 10s timeout) fetch only the top 100 repos by stars
-    // in one query. Run as a GitHub Action / CLI (own token, no timeout) paginate
-    // every repo for accurate totals. totalPublicRepos is always exact (totalCount).
+    // On Vercel, totals are sampled from the first pages of repos (natural order,
+    // capped by VERCEL_MAX_ORG_DETAIL_PAGES and the pagination time budget — star
+    // ordering 502s GitHub-side for mega orgs). Run as a GitHub Action / CLI (own
+    // token, no limits) every repo is paginated for exact totals. totalPublicRepos
+    // is always exact (totalCount).
     // Raw org info + node list are cached per login; the OrganizationDetails
     // instance (with real Date objects) is assembled after the cache boundary.
     const {org, nodes} = await withDataCache(`v1:od:${login.toLowerCase()}`, async () => {


### PR DESCRIPTION
Worst-case matrix testing before v0.10.2 caught org profile/stats cards for **microsoft** and **google** (7,000+ repos) still 504ing after #287.

Measured directly: `orderBy: STARGAZERS` on the org-details query 502s GitHub-side at that scale (10.8s → Bad Gateway), natural order returns in 3.7s — the same failure mode #287 fixed for user queries. The org **language** cards keep their ordering: both were measured fine on microsoft (first:50 / lighter fields).

- org-details drops the star ordering and gains the 12s pagination budget
- totals for 300+-repo orgs are sampled from the first pages (as before, just no longer top-by-stars); orgs under 300 repos are exact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved organization repository pagination behavior by refining the “fetch next page” decision logic.
  * Updated organization repository retrieval to stop applying a star-based sort order, so results follow the service’s default ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->