### PR TITLE
fix: split per-year query on GitHub resource-limit rejections

### DIFF
--- a/src/github-api/contributions-by-year.ts
+++ b/src/github-api/contributions-by-year.ts
@@ -1,4 +1,4 @@
-import request, {assertNoGraphQLErrors} from '../utils/request';
+import request, {assertNoGraphQLErrors, GraphQLError} from '../utils/request';
 import {withDataCache, PrimedReads} from '../utils/data-cache';
 
 export class ConrtibutionByYear {
@@ -38,6 +38,52 @@ const fetcher = (token: string, variables: any) => {
     );
 };
 
+// Split variants of the query above. GitHub's cost estimator rejects the
+// combined query with "Resource limits for this query exceeded" for some
+// mega-contribution user-years (e.g. gaearon 2017: >10k commits) while each
+// field queried on its own succeeds — same data, two cheaper documents.
+const commitCountFetcher = (token: string, variables: any) => {
+    return request(
+        {
+            Authorization: `bearer ${token}`
+        },
+        {
+            query: `
+      query ContributionsByYearCommits($login: String!, $from: DateTime, $to: DateTime) {
+        user(login: $login) {
+            contributionsCollection(from: $from, to: $to) {
+                totalCommitContributions
+            }
+        }
+      }
+      `,
+            variables
+        }
+    );
+};
+
+const calendarTotalFetcher = (token: string, variables: any) => {
+    return request(
+        {
+            Authorization: `bearer ${token}`
+        },
+        {
+            query: `
+      query ContributionsByYearCalendar($login: String!, $from: DateTime, $to: DateTime) {
+        user(login: $login) {
+            contributionsCollection(from: $from, to: $to) {
+                contributionCalendar {
+                    totalContributions
+                }
+            }
+        }
+      }
+      `,
+            variables
+        }
+    );
+};
+
 /**
  * Cache key for one (user, year) contribution total — exported so callers
  * iterating many years can batch-read them with primeDataCache.
@@ -61,19 +107,36 @@ export async function getContributionByYear(
     const raw = await withDataCache(
         contributionYearCacheKey(username, year),
         async () => {
-            const res = await fetcher(token, {
+            const variables = {
                 login: username,
                 from: year ? `${year}-01-01T00:00:00Z` : null,
                 to: year ? `${year}-12-31T23:59:59Z` : null
-            });
-
-            assertNoGraphQLErrors(res, 'GetContributionByYear failed');
-
-            const user = res.data.data.user;
-            return {
-                totalCommitContributions: user.contributionsCollection.totalCommitContributions as number,
-                totalContributions: user.contributionsCollection.contributionCalendar.totalContributions as number
             };
+            try {
+                const res = await fetcher(token, variables);
+                assertNoGraphQLErrors(res, 'GetContributionByYear failed');
+                const user = res.data.data.user;
+                return {
+                    totalCommitContributions: user.contributionsCollection.totalCommitContributions as number,
+                    totalContributions: user.contributionsCollection.contributionCalendar.totalContributions as number
+                };
+            } catch (err) {
+                if (!(err as GraphQLError).isResourceLimit) throw err;
+                // Combined document rejected for this mega-contribution year —
+                // fetch the same two numbers with one query each.
+                const [commitsRes, calendarRes] = await Promise.all([
+                    commitCountFetcher(token, variables),
+                    calendarTotalFetcher(token, variables)
+                ]);
+                assertNoGraphQLErrors(commitsRes, 'GetContributionByYear (split commits) failed');
+                assertNoGraphQLErrors(calendarRes, 'GetContributionByYear (split calendar) failed');
+                return {
+                    totalCommitContributions: commitsRes.data.data.user.contributionsCollection
+                        .totalCommitContributions as number,
+                    totalContributions: calendarRes.data.data.user.contributionsCollection.contributionCalendar
+                        .totalContributions as number
+                };
+            }
         },
         // Past years are immutable: long fresh window, retention slightly past it
         // so the fresh window is actually usable (retention is the Redis EX).

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -5,9 +5,11 @@ import axios, {AxiosPromise} from 'axios';
 rax.attach();
 
 // An error thrown from the GraphQL layer, optionally flagged as a rate-limit so
-// callers can rotate to another token.
+// callers can rotate to another token, or as a resource-limit rejection so
+// callers can retry with a cheaper query shape.
 export interface GraphQLError extends Error {
     isRateLimit?: boolean;
+    isResourceLimit?: boolean;
 }
 
 // GitHub's GraphQL API returns rate-limit failures as HTTP 200 with an `errors`
@@ -21,6 +23,13 @@ export function assertNoGraphQLErrors(res: any, fallbackMessage: string): void {
         const err: GraphQLError = new Error(errors[0].message || fallbackMessage);
         if (errors.some((e: any) => e?.type === 'RATE_LIMITED')) {
             err.isRateLimit = true;
+        }
+        // "Resource limits for this query exceeded" — GitHub's cost estimator
+        // rejecting the query document. For mega-contribution accounts a
+        // combined query can trip it while each field alone stays under the
+        // limit, so callers may retry with a split query.
+        if (errors.some((e: any) => /resource limits/i.test(e?.message ?? ''))) {
+            err.isResourceLimit = true;
         }
         throw err;
     }

--- a/tests/github-api/contributions-by-year.test.ts
+++ b/tests/github-api/contributions-by-year.test.ts
@@ -46,4 +46,46 @@ describe('contributions count on github', () => {
         mock.onPost('https://api.github.com/graphql').reply(200, error);
         await expect(getContributionByYear('vn7n24fzkq', 2020, 'token')).rejects.toThrow('GitHub api failed');
     });
+
+    it('falls back to split queries when the combined one hits GitHub resource limits', async () => {
+        const resourceLimit = {
+            errors: [{type: 'EXCESSIVE_PAGINATION', message: 'Resource limits for this query exceeded.'}]
+        };
+        const commitsOnly = {
+            data: {user: {contributionsCollection: {totalCommitContributions: 10270}}}
+        };
+        const calendarOnly = {
+            data: {user: {contributionsCollection: {contributionCalendar: {totalContributions: 11929}}}}
+        };
+        mock.onPost('https://api.github.com/graphql').replyOnce(200, resourceLimit);
+        // The two split queries fire in parallel; route them by operation name.
+        mock.onPost('https://api.github.com/graphql').reply(config => {
+            const body = JSON.parse(config.data);
+            if (body.query.includes('ContributionsByYearCommits')) return [200, commitsOnly];
+            if (body.query.includes('ContributionsByYearCalendar')) return [200, calendarOnly];
+            return [500, {}];
+        });
+
+        const result = await getContributionByYear('gaearon', 2017, 'token');
+        expect(result).toEqual({
+            totalCommitContributions: 10270,
+            totalContributions: 11929,
+            year: 2017
+        });
+    });
+
+    it('does not split on non-resource-limit errors', async () => {
+        mock.onPost('https://api.github.com/graphql').reply(200, error);
+        await expect(getContributionByYear('vn7n24fzkq', 2020, 'token')).rejects.toThrow('GitHub api failed');
+        // one combined attempt, no fallback requests
+        expect(mock.history.post).toHaveLength(1);
+    });
+
+    it('propagates errors from the split queries themselves', async () => {
+        const resourceLimit = {
+            errors: [{message: 'Resource limits for this query exceeded.'}]
+        };
+        mock.onPost('https://api.github.com/graphql').reply(200, resourceLimit);
+        await expect(getContributionByYear('gaearon', 2017, 'token')).rejects.toThrow(/resource limits/i);
+    });
 });

--- a/tests/utils/request.test.ts
+++ b/tests/utils/request.test.ts
@@ -31,4 +31,17 @@ describe('assertNoGraphQLErrors', () => {
             expect(e.isRateLimit).toBeUndefined();
         }
     });
+
+    it('flags resource-limit errors with isResourceLimit so callers can split the query', () => {
+        expect.assertions(2);
+        try {
+            assertNoGraphQLErrors(
+                {data: {errors: [{message: 'Resource limits for this query exceeded.'}]}},
+                'fallback'
+            );
+        } catch (e: any) {
+            expect(e.isResourceLimit).toBe(true);
+            expect(e.isRateLimit).toBeUndefined();
+        }
+    });
 });


### PR DESCRIPTION
## Problem

v0.11.0's full-history totals query **every** contribution year — which newly exposed us to a GitHub quirk: the cost estimator rejects our combined per-year document (`totalCommitContributions` + `contributionCalendar.totalContributions`) with **"Resource limits for this query exceeded"** for mega-contribution user-years. gaearon's 2017/2018/2024 fail this way 100% reproducibly, which error-carded his stats and profile-details cards (regression vs v0.10.2, which only queried the latest year).

## Fix

`assertNoGraphQLErrors` now flags these rejections with `isResourceLimit`; the per-year fetcher catches that flag and retries as **two parallel single-field queries** (each stays under the estimator's limit — verified against the live API), merging the result. Only affected years pay the extra request; everything else is untouched. Non-resource errors propagate exactly as before.

## Verified

- Live API: gaearon 2017 split → 10,270 commits / 11,929 contributions; full history converges to **68,630 commits / 77,898 contributions**, warm renders ~300ms
- 3 new tests for the fallback (split success, no split on other errors, split-failure propagation) + 1 for the flag; full suite green

## Not fixed here (GitHub-side, tracked separately)

antfu / kentcdodds-class accounts fail even a **bare calendar query** — no client-side query shape can help; their cards error until GitHub's contributions service recovers for those accounts. Predates v0.11.0 (no cached profile data existed for them within the 7-day retention window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when retrieving contribution data for years with large activity volumes.
  - Automatically retries resource-limit failures using separate commit and calendar requests.
  - Preserves normal error handling for unrelated GraphQL failures.
- **Tests**
  - Added coverage for fallback requests, error propagation, and resource-limit detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->