### PR TITLE
fix: rotate tokens on typeless 'rate limit already exceeded' errors

### DIFF
--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -21,7 +21,12 @@ export function assertNoGraphQLErrors(res: any, fallbackMessage: string): void {
     const errors = res?.data?.errors;
     if (Array.isArray(errors) && errors.length > 0) {
         const err: GraphQLError = new Error(errors[0].message || fallbackMessage);
-        if (errors.some((e: any) => e?.type === 'RATE_LIMITED')) {
+        // GitHub reports GraphQL rate limiting two ways: type RATE_LIMITED, and
+        // (once the quota is fully spent) a typeless error reading "API rate
+        // limit already exceeded for user ID ...". Matching only the type missed
+        // the second form, so token rotation never engaged during a real
+        // exhaustion — exactly when it matters most.
+        if (errors.some((e: any) => e?.type === 'RATE_LIMITED' || /rate limit/i.test(e?.message ?? ''))) {
             err.isRateLimit = true;
         }
         // "Resource limits for this query exceeded" — GitHub's cost estimator

--- a/tests/utils/request.test.ts
+++ b/tests/utils/request.test.ts
@@ -23,6 +23,18 @@ describe('assertNoGraphQLErrors', () => {
         }
     });
 
+    it('flags typeless "rate limit already exceeded" errors too (production outage 2026-07-17)', () => {
+        expect.assertions(1);
+        try {
+            assertNoGraphQLErrors(
+                {data: {errors: [{message: 'API rate limit already exceeded for user ID 305432014.'}]}},
+                'fallback'
+            );
+        } catch (e: any) {
+            expect(e.isRateLimit).toBe(true);
+        }
+    });
+
     it('does not flag non-rate-limit errors', () => {
         expect.assertions(1);
         try {


### PR DESCRIPTION
## Active incident

Since the v0.11.0 full-history backfill started, the primary (machine-account) token exhausts its 5k/hr window and **every cold render error-cards without ever rotating to the fallback token** (observed sitting untouched at 4,999/5,000 remaining while production logged `API rate limit already exceeded for user ID 305432014` on every request).

## Root cause

GitHub reports GraphQL rate limiting two ways:
1. `{type: "RATE_LIMITED", ...}` — matched by `isRateLimit`, rotation works
2. once the quota is **fully spent**: a **typeless** error `"API rate limit already exceeded for user ID ..."` (HTTP 200, no `response.status`) — matched by nothing, so `isRotatableError` returned false and the card failed on the spot

## Fix

`assertNoGraphQLErrors` now flags `isRateLimit` when the type is `RATE_LIMITED` **or** the message matches `/rate limit/i`. No overlap with the resource-limit fallback (#291) — "Resource limits for this query exceeded" doesn't contain the phrase.

With rotation working, the fallback token's 5k/hr absorbs the backfill overflow (combined 10k/hr vs. measured ~5-6k/hr peak demand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of GitHub API rate-limit errors, including responses that omit a specific error type.
  - Enables more reliable recovery when rate limits are reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->