### PR TITLE
feat(cache): jitter past-year fresh windows to prevent expiry stampedes

### DIFF
--- a/src/github-api/commits-per-language.ts
+++ b/src/github-api/commits-per-language.ts
@@ -1,5 +1,7 @@
 import request, {assertNoGraphQLErrors} from '../utils/request';
-import {withDataCache, primeDataCache, PrimedReads} from '../utils/data-cache';
+import {withDataCache, primeDataCache, jitteredSeconds, PrimedReads} from '../utils/data-cache';
+
+const DAY = 24 * 60 * 60;
 import {VERCEL_PAGINATION_BUDGET_MS} from '../const/pagination';
 
 export class CommitLanguageInfo {
@@ -123,8 +125,11 @@ async function getCommitContributionsForYear(
     primed?: PrimedReads
 ): Promise<CommitContributionNode[]> {
     const isPastYear = year < new Date().getFullYear();
+    // Jittered per key (90d ± 15d) so burst-cached keys don't expire together.
+    const key = commitLanguageYearCacheKey(username, year);
+    const freshSeconds = jitteredSeconds(key, 90 * DAY, 15 * DAY);
     return withDataCache(
-        commitLanguageYearCacheKey(username, year),
+        key,
         async () => {
             const res = await fetcher(token, {
                 login: username,
@@ -135,7 +140,7 @@ async function getCommitContributionsForYear(
             return res.data.data.user.contributionsCollection.commitContributionsByRepository;
         },
         // Past years are immutable — cache long; the current year refreshes.
-        isPastYear ? {freshSeconds: 90 * 24 * 60 * 60, retentionSeconds: 100 * 24 * 60 * 60, primed} : {primed}
+        isPastYear ? {freshSeconds, retentionSeconds: freshSeconds + 10 * DAY, primed} : {primed}
     );
 }
 

--- a/src/github-api/contributions-by-year.ts
+++ b/src/github-api/contributions-by-year.ts
@@ -1,5 +1,7 @@
 import request, {assertNoGraphQLErrors, GraphQLError} from '../utils/request';
-import {withDataCache, PrimedReads} from '../utils/data-cache';
+import {withDataCache, jitteredSeconds, PrimedReads} from '../utils/data-cache';
+
+const DAY = 24 * 60 * 60;
 
 export class ConrtibutionByYear {
     year: number;
@@ -103,9 +105,14 @@ export async function getContributionByYear(
     primed?: PrimedReads
 ): Promise<ConrtibutionByYear> {
     // Past years never change — cache them for much longer than the current one.
+    // The fresh window is jittered per key (90d ± 15d) so keys cached in the
+    // same burst don't all expire together; retention stays 10d past fresh so
+    // the stale-rescue window survives a slow re-fetch cycle.
     const isPastYear = !!year && year < new Date().getFullYear();
+    const key = contributionYearCacheKey(username, year);
+    const freshSeconds = jitteredSeconds(key, 90 * DAY, 15 * DAY);
     const raw = await withDataCache(
-        contributionYearCacheKey(username, year),
+        key,
         async () => {
             const variables = {
                 login: username,
@@ -138,9 +145,7 @@ export async function getContributionByYear(
                 };
             }
         },
-        // Past years are immutable: long fresh window, retention slightly past it
-        // so the fresh window is actually usable (retention is the Redis EX).
-        isPastYear ? {freshSeconds: 90 * 24 * 60 * 60, retentionSeconds: 100 * 24 * 60 * 60, primed} : {primed}
+        isPastYear ? {freshSeconds, retentionSeconds: freshSeconds + 10 * DAY, primed} : {primed}
     );
 
     return new ConrtibutionByYear(year, raw.totalCommitContributions, raw.totalContributions);

--- a/src/utils/data-cache.ts
+++ b/src/utils/data-cache.ts
@@ -88,6 +88,37 @@ function kvConfigured(): boolean {
     return !!process.env.KV_REST_API_URL && !!process.env.KV_REST_API_TOKEN;
 }
 
+/**
+ * Spreads a cache window deterministically per key: baseSeconds ± spreadSeconds,
+ * derived from a hash of the key. Keys written in the same burst (e.g. the
+ * full-history backfill caching thousands of accounts in one day) would
+ * otherwise all expire together and repeat the burst as a re-fetch storm every
+ * cycle. Hash-based (not random) so every read and write of the same key — on
+ * any lambda instance — agrees on the same window.
+ *
+ * @param {string} key - The cache key to derive the jitter from.
+ * @param {number} baseSeconds - The centre of the window.
+ * @param {number} spreadSeconds - Maximum deviation in either direction.
+ * @return {number} A stable value in [base - spread, base + spread].
+ */
+export function jitteredSeconds(key: string, baseSeconds: number, spreadSeconds: number): number {
+    // FNV-1a with a murmur3-style finalizer: similar keys (same user, adjacent
+    // years) must land far apart, and a plain rolling hash has no avalanche —
+    // adjacent inputs map to adjacent fractions and the jitter collapses.
+    let h = 0x811c9dc5;
+    for (let i = 0; i < key.length; i++) {
+        h ^= key.charCodeAt(i);
+        h = Math.imul(h, 0x01000193);
+    }
+    h ^= h >>> 16;
+    h = Math.imul(h, 0x85ebca6b);
+    h ^= h >>> 13;
+    h = Math.imul(h, 0xc2b2ae35);
+    h ^= h >>> 16;
+    const fraction = (h >>> 0) / 0xffffffff; // stable in [0, 1]
+    return Math.round(baseSeconds + (fraction - 0.5) * 2 * spreadSeconds);
+}
+
 // ---- circuit breaker state (per lambda instance) ----
 // Reads and writes are tracked separately: during a write-only outage (e.g.
 // Redis out of memory) reads keep succeeding, and a shared streak would be

--- a/tests/utils/data-cache.test.ts
+++ b/tests/utils/data-cache.test.ts
@@ -2,6 +2,7 @@ import {
     withDataCache,
     primeDataCache,
     runWithCacheStats,
+    jitteredSeconds,
     isKvHealthy,
     resetKvHealthForTests
 } from '../../src/utils/data-cache';
@@ -285,6 +286,34 @@ describe('circuit breaker', () => {
         } finally {
             nowSpy.mockRestore();
         }
+    });
+});
+
+describe('jitteredSeconds', () => {
+    const DAY = 24 * 60 * 60;
+
+    it('is deterministic for the same key', () => {
+        expect(jitteredSeconds('v1:cy:torvalds:2015', 90 * DAY, 15 * DAY)).toBe(
+            jitteredSeconds('v1:cy:torvalds:2015', 90 * DAY, 15 * DAY)
+        );
+    });
+
+    it('stays within base ± spread', () => {
+        for (let year = 2008; year <= 2026; year++) {
+            const v = jitteredSeconds(`v1:cy:someuser:${year}`, 90 * DAY, 15 * DAY);
+            expect(v).toBeGreaterThanOrEqual(75 * DAY);
+            expect(v).toBeLessThanOrEqual(105 * DAY);
+        }
+    });
+
+    it('actually spreads different keys apart (anti-stampede)', () => {
+        const values = new Set<number>();
+        for (let year = 2008; year <= 2026; year++) {
+            values.add(jitteredSeconds(`v1:cly:someuser:${year}`, 90 * DAY, 15 * DAY));
+        }
+        // 19 keys landing on fewer than 10 distinct values would mean the hash
+        // is clustering — the whole point is that a burst spreads out.
+        expect(values.size).toBeGreaterThanOrEqual(10);
     });
 });
 


### PR DESCRIPTION
## Problem

The v0.11.0 full-history backfill wrote thousands of accounts' past-year cache keys within a day or two, all with a fixed 90-day fresh window — a synchronized expiry cohort that would re-run the backfill as a GitHub-quota storm around mid-October, and every ~90 days after that.

## Change

Past-year fresh windows (`v1:cy`, `v1:cly`) are now **jittered per key: 90d ± 15d**, derived deterministically from an FNV-1a hash with a murmur3-style finalizer — every read and write of the same key on any lambda instance agrees on the same window, while a burst cohort spreads its expiries across a month. Retention follows at fresh + 10d, preserving the stale-rescue overlap (an expired-fresh key still serves stale if the re-fetch hits a rate limit).

A plain rolling hash (`h*31+c`) was tried first and collapsed: adjacent `user:year` keys have no avalanche and every year landed on the same window — there's a regression test asserting real spread now.

## Semantics

None changed — past years are immutable, so a longer-or-shorter fresh window only affects *when* the (identical) data is re-fetched. Current-year windows are untouched.

Verified: 19 consecutive year keys → 19 distinct windows across 77–105d; 173 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved refresh timing for historical contribution data by using deterministic, per-key jittered cache windows instead of fixed durations.
  - Helps spread updates over time to reduce refresh spikes and keep historical data more consistently available.
- **Tests**
  - Added coverage for deterministic jitter values, ensuring they stay within the expected bounds and are well distributed across different keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->