### PR TITLE
fix: half-year window fallback for resource-limited commit-language years

### DIFF
--- a/src/github-api/commits-per-language.ts
+++ b/src/github-api/commits-per-language.ts
@@ -1,4 +1,4 @@
-import request, {assertNoGraphQLErrors} from '../utils/request';
+import request, {assertNoGraphQLErrors, GraphQLError} from '../utils/request';
 import {withDataCache, primeDataCache, PrimedReads} from '../utils/data-cache';
 import {VERCEL_PAGINATION_BUDGET_MS} from '../const/pagination';
 
@@ -116,6 +116,17 @@ function commitLanguageYearCacheKey(username: string, year: number): string {
     return `v1:cly:${username.toLowerCase()}:${year}`;
 }
 
+async function fetchCommitContributionsWindow(
+    username: string,
+    token: string,
+    from: string,
+    to: string
+): Promise<CommitContributionNode[]> {
+    const res = await fetcher(token, {login: username, from, to});
+    assertNoGraphQLErrors(res, 'GetCommitLanguage failed');
+    return res.data.data.user.contributionsCollection.commitContributionsByRepository;
+}
+
 async function getCommitContributionsForYear(
     username: string,
     year: number,
@@ -126,13 +137,39 @@ async function getCommitContributionsForYear(
     return withDataCache(
         commitLanguageYearCacheKey(username, year),
         async () => {
-            const res = await fetcher(token, {
-                login: username,
-                from: `${year}-01-01T00:00:00Z`,
-                to: `${year}-12-31T23:59:59Z`
-            });
-            assertNoGraphQLErrors(res, 'GetCommitLanguage failed');
-            return res.data.data.user.contributionsCollection.commitContributionsByRepository;
+            try {
+                return await fetchCommitContributionsWindow(
+                    username,
+                    token,
+                    `${year}-01-01T00:00:00Z`,
+                    `${year}-12-31T23:59:59Z`
+                );
+            } catch (err) {
+                if (!(err as GraphQLError).isResourceLimit) throw err;
+                // GitHub's cost estimator rejects mega-contribution user-years
+                // outright ("Resource limits for this query exceeded") at ANY
+                // maxRepositories — but a smaller time window scores lower, and
+                // two half-year windows pass (verified on gaearon 2017: 10k+
+                // commits). Same repos; a repo active in both halves appears
+                // twice and its counts sum correctly during aggregation. Halves
+                // that hit the 100-repo cap even cover MORE repos than a capped
+                // full year would.
+                const [h1, h2] = await Promise.all([
+                    fetchCommitContributionsWindow(
+                        username,
+                        token,
+                        `${year}-01-01T00:00:00Z`,
+                        `${year}-06-30T23:59:59Z`
+                    ),
+                    fetchCommitContributionsWindow(
+                        username,
+                        token,
+                        `${year}-07-01T00:00:00Z`,
+                        `${year}-12-31T23:59:59Z`
+                    )
+                ]);
+                return [...h1, ...h2];
+            }
         },
         // Past years are immutable — cache long; the current year refreshes.
         isPastYear ? {freshSeconds: 90 * 24 * 60 * 60, retentionSeconds: 100 * 24 * 60 * 60, primed} : {primed}

--- a/tests/github-api/commits-per-language.test.ts
+++ b/tests/github-api/commits-per-language.test.ts
@@ -85,6 +85,33 @@ describe('commit contributions on github (full history)', () => {
         );
     });
 
+    it('falls back to two half-year windows when the full year hits GitHub resource limits', async () => {
+        const resourceLimit = {errors: [{message: 'Resource limits for this query exceeded.'}]};
+        mock.onPost('https://api.github.com/graphql').reply(config => {
+            const vars = JSON.parse(config.data).variables;
+            if (vars.from === '2023-01-01T00:00:00Z' && vars.to === '2023-12-31T23:59:59Z') {
+                return [200, resourceLimit];
+            }
+            if (vars.to === '2023-06-30T23:59:59Z') return [200, yearData([rust99, js84])];
+            if (vars.from === '2023-07-01T00:00:00Z') return [200, yearData([rust100, jupyter75])];
+            return [500, {}];
+        });
+        const langs = await getCommitLanguageAllYears('jerry153fish', [], 'token', [], [2023]);
+        const map = langs.getLanguageMap();
+        // repo counts from both halves merge by language
+        expect(map.get('Rust')?.count).toBe(199);
+        expect(map.get('JavaScript')?.count).toBe(84);
+        expect(map.get('Jupyter Notebook')?.count).toBe(75);
+    });
+
+    it('does not use half-year windows on other errors', async () => {
+        mock.onPost('https://api.github.com/graphql').reply(200, error);
+        await expect(getCommitLanguageAllYears('vn7n24fzkq', [], 'token', [], [2023])).rejects.toThrow(
+            'GitHub api failed'
+        );
+        expect(mock.history.post).toHaveLength(1); // no fallback attempts
+    });
+
     it('should do a case-insensitive comparison for language exclusion', async () => {
         mock.onPost('https://api.github.com/graphql').reply(200, yearData([rust99, js84, jupyter75]));
         const langs = await getCommitLanguageAllYears('vn7n24fzkq', ['jupyter notebook'], 'token', [], [2026]);


### PR DESCRIPTION
## Problem (user report)

`/api/cards/most-commit-language?username=jerry153fish` error-cards with `Resource limits for this query exceeded` — his 2023 `commitContributionsByRepository` query is rejected by GitHub's cost estimator. #291 fixed the same rejection for the contributions total query by splitting fields, but this query has only one field, and lowering `maxRepositories` (100→50→25→10) doesn't help — the estimator rejects the user-year outright.

## Fix: shrink the *time window* instead

A smaller window scores lower: **two half-year windows pass even for gaearon 2017** (10k+ commits — the extreme case that failed at every page size). On `isResourceLimit`, the year re-fetches as two parallel half-year queries and the node lists concatenate. A repo active in both halves appears twice and its counts sum correctly during language aggregation — same totals. Halves that hit the 100-repo cap actually cover **more** repos than a capped full year (gaearon 2017: 100+90 vs. a truncated 100).

Only rejected years pay the extra request; everything else is untouched.

## Verified live

- jerry153fish: full history completes — Rust 221 / Go 156 / Python 55 (10.7s cold, then cached)
- gaearon: donut previously unfixable, now completes — JavaScript 35,117 / TypeScript 31,991, 644ms warm
- 2 new tests (fallback merge, no fallback on other errors); full suite green

## Bonus finding (follow-up, not in this PR)

The same trick cracks the antfu-class profile failures: **half-window calendars pass** where the full default-range calendar is rejected. Only `repositoriesContributedTo` (no window parameter) remains rejected for those accounts — a UserDetails split is a candidate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving yearly commit contributions from GitHub.
  * Automatically retries resource-limited requests using smaller half-year date ranges.
  * Preserves other API errors without triggering unnecessary retries.

* **Tests**
  * Added coverage for resource-limit fallback behavior and other API failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->