### PR TITLE
fix: tiered split fallback for resource-limited UserDetails queries

### DIFF
--- a/src/github-api/profile-details.ts
+++ b/src/github-api/profile-details.ts
@@ -224,16 +224,24 @@ async function fetchCalendarWeeks(username: string, token: string): Promise<Cale
         if (!(err as GraphQLError).isResourceLimit) throw err;
         // Even the trailing-year calendar alone is rejected for the most active
         // accounts — two disjoint half-windows score low enough to pass, and
-        // their days concatenate into the same daily series.
-        const now = Date.now();
-        const mid = new Date(now - 182 * 24 * 60 * 60 * 1000);
-        const start = new Date(now - 364 * 24 * 60 * 60 * 1000);
+        // their days concatenate into the same daily series. The seam sits on a
+        // UTC day boundary: the calendar buckets by day, so a mid-day cut would
+        // put the boundary date into both halves.
+        const DAY_MS = 24 * 60 * 60 * 1000;
+        const now = new Date();
+        const todayStartUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+        const midStart = new Date(todayStartUtc - 182 * DAY_MS); // 00:00:00Z — first day of H2
+        const start = new Date(todayStartUtc - 364 * DAY_MS);
         const [h1, h2] = await Promise.all([
-            calendarFetcher(token, {login: username, from: start.toISOString(), to: mid.toISOString()}),
             calendarFetcher(token, {
                 login: username,
-                from: new Date(mid.getTime() + 1000).toISOString(),
-                to: new Date(now).toISOString()
+                from: start.toISOString(),
+                to: new Date(midStart.getTime() - 1).toISOString() // 23:59:59.999Z of H1's last day
+            }),
+            calendarFetcher(token, {
+                login: username,
+                from: midStart.toISOString(),
+                to: now.toISOString()
             })
         ]);
         assertNoGraphQLErrors(h1, 'GetProfileDetails (calendar H1) failed');

--- a/src/github-api/profile-details.ts
+++ b/src/github-api/profile-details.ts
@@ -1,4 +1,4 @@
-import request, {assertNoGraphQLErrors} from '../utils/request';
+import request, {assertNoGraphQLErrors, GraphQLError} from '../utils/request';
 import {shouldFetchNextPage} from '../const/pagination';
 import {withDataCache} from '../utils/data-cache';
 
@@ -95,6 +95,183 @@ const fetcher = (token: string, variables: any) => {
     );
 };
 
+// ---- Split variants of UserDetails ----
+// GitHub's cost estimator scores the whole document; for very active accounts
+// the combined UserDetails query is rejected with "Resource limits for this
+// query exceeded" while smaller documents pass. The split keeps the exact same
+// fields, just spread across three cheaper queries (plus a half-window
+// calendar fallback for the most extreme accounts).
+
+const coreFetcher = (token: string, variables: any) => {
+    return request(
+        {
+            Authorization: `bearer ${token}`
+        },
+        {
+            query: `
+      query UserDetailsCore($login: String!) {
+        user(login: $login) {
+            id
+            name
+            email
+            createdAt
+            twitterUsername
+            company
+            location
+            websiteUrl
+            repositories(first: 100,privacy:PUBLIC, isFork: false, ownerAffiliations: OWNER) {
+              totalCount
+              nodes {
+                stargazers {
+                  totalCount
+                }
+              }
+              pageInfo {
+                endCursor
+                hasNextPage
+              }
+            }
+        }
+      }
+      `,
+            variables
+        }
+    );
+};
+
+const calendarFetcher = (token: string, variables: any) => {
+    // Null from/to falls back to GitHub's default trailing-year window.
+    return request(
+        {
+            Authorization: `bearer ${token}`
+        },
+        {
+            query: `
+      query UserDetailsCalendar($login: String!, $from: DateTime, $to: DateTime) {
+        user(login: $login) {
+            contributionsCollection(from: $from, to: $to) {
+                contributionCalendar {
+                    weeks {
+                        contributionDays {
+                            contributionCount
+                            date
+                        }
+                    }
+                }
+            }
+        }
+      }
+      `,
+            variables
+        }
+    );
+};
+
+const contributionYearsFetcher = (token: string, variables: any) => {
+    return request(
+        {
+            Authorization: `bearer ${token}`
+        },
+        {
+            query: `
+      query UserDetailsYears($login: String!) {
+        user(login: $login) {
+            contributionsCollection {
+                contributionYears
+            }
+        }
+      }
+      `,
+            variables
+        }
+    );
+};
+
+const countsFetcher = (token: string, variables: any) => {
+    return request(
+        {
+            Authorization: `bearer ${token}`
+        },
+        {
+            query: `
+      query UserDetailsCounts($login: String!) {
+        user(login: $login) {
+            repositoriesContributedTo(first: 1,includeUserRepositories:true, privacy:PUBLIC, contributionTypes: [COMMIT, ISSUE, PULL_REQUEST, REPOSITORY]) {
+                totalCount
+            }
+            pullRequests(first: 1) {
+                totalCount
+            }
+            issues(first: 1) {
+                totalCount
+            }
+        }
+      }
+      `,
+            variables
+        }
+    );
+};
+
+type CalendarWeek = {contributionDays: {contributionCount: number; date: string}[]};
+
+async function fetchCalendarWeeks(username: string, token: string): Promise<CalendarWeek[]> {
+    try {
+        const res = await calendarFetcher(token, {login: username, from: null, to: null});
+        assertNoGraphQLErrors(res, 'GetProfileDetails (calendar) failed');
+        return res.data.data.user.contributionsCollection.contributionCalendar.weeks;
+    } catch (err) {
+        if (!(err as GraphQLError).isResourceLimit) throw err;
+        // Even the trailing-year calendar alone is rejected for the most active
+        // accounts — two disjoint half-windows score low enough to pass, and
+        // their days concatenate into the same daily series.
+        const now = Date.now();
+        const mid = new Date(now - 182 * 24 * 60 * 60 * 1000);
+        const start = new Date(now - 364 * 24 * 60 * 60 * 1000);
+        const [h1, h2] = await Promise.all([
+            calendarFetcher(token, {login: username, from: start.toISOString(), to: mid.toISOString()}),
+            calendarFetcher(token, {
+                login: username,
+                from: new Date(mid.getTime() + 1000).toISOString(),
+                to: new Date(now).toISOString()
+            })
+        ]);
+        assertNoGraphQLErrors(h1, 'GetProfileDetails (calendar H1) failed');
+        assertNoGraphQLErrors(h2, 'GetProfileDetails (calendar H2) failed');
+        return [
+            ...h1.data.data.user.contributionsCollection.contributionCalendar.weeks,
+            ...h2.data.data.user.contributionsCollection.contributionCalendar.weeks
+        ];
+    }
+}
+
+// Rebuilds the exact `user` object shape of the combined UserDetails query
+// from the three split queries, so the code after the cache boundary doesn't
+// care which path produced it.
+async function fetchUserDetailsSplit(username: string, token: string): Promise<any> {
+    const [coreRes, weeks, yearsRes, countsRes] = await Promise.all([
+        coreFetcher(token, {login: username}),
+        fetchCalendarWeeks(username, token),
+        contributionYearsFetcher(token, {login: username}),
+        countsFetcher(token, {login: username})
+    ]);
+    assertNoGraphQLErrors(coreRes, 'GetProfileDetails (core) failed');
+    assertNoGraphQLErrors(yearsRes, 'GetProfileDetails (years) failed');
+    assertNoGraphQLErrors(countsRes, 'GetProfileDetails (counts) failed');
+    const core = coreRes.data.data.user;
+    const counts = countsRes.data.data.user;
+    return {
+        ...core,
+        contributionsCollection: {
+            contributionCalendar: {weeks},
+            contributionYears: yearsRes.data.data.user.contributionsCollection.contributionYears
+        },
+        repositoriesContributedTo: counts.repositoriesContributedTo,
+        pullRequests: counts.pullRequests,
+        issues: counts.issues
+    };
+}
+
 // Lightweight follow-up query used only to finish the star count for accounts
 // with more than 100 repos — the heavy fields (contribution calendar etc.) all
 // come from the first page.
@@ -131,13 +308,19 @@ export async function getProfileDetails(username: string, token: string): Promis
     // The ProfileDetails instance (with real Date objects) is built after the
     // cache boundary so only plain JSON is ever stored.
     const {user, totalStars} = await withDataCache(`v1:pd:${username.toLowerCase()}`, async () => {
-        const res = await fetcher(token, {
-            login: username
-        });
-
-        assertNoGraphQLErrors(res, 'GetProfileDetails failed');
-
-        const fetchedUser = res.data.data.user;
+        let fetchedUser: any;
+        try {
+            const res = await fetcher(token, {
+                login: username
+            });
+            assertNoGraphQLErrors(res, 'GetProfileDetails failed');
+            fetchedUser = res.data.data.user;
+        } catch (err) {
+            if (!(err as GraphQLError).isResourceLimit) throw err;
+            // The combined document was rejected for this very active account —
+            // fetch the same fields via three smaller queries instead.
+            fetchedUser = await fetchUserDetailsSplit(username, token);
+        }
         let stars: number = fetchedUser.repositories.nodes.reduce(
             (acc: number, curr: {stargazers: {totalCount: number}}) => acc + curr.stargazers.totalCount,
             0

--- a/tests/github-api/profile-details.test.ts
+++ b/tests/github-api/profile-details.test.ts
@@ -108,6 +108,147 @@ describe('github api for profile details', () => {
         await expect(getProfileDetails('vn7n24fzkq', 'token')).rejects.toThrow('GitHub api failed');
     });
 
+    it('falls back to split queries when the combined document hits resource limits', async () => {
+        const resourceLimit = {errors: [{message: 'Resource limits for this query exceeded.'}]};
+        const u = data.data.user;
+        mock.onPost('https://api.github.com/graphql').reply(config => {
+            const body = JSON.parse(config.data);
+            if (body.query.includes('query UserDetails(')) return [200, resourceLimit];
+            if (body.query.includes('UserDetailsCore')) {
+                return [
+                    200,
+                    {
+                        data: {
+                            user: {
+                                id: u.id,
+                                name: u.name,
+                                email: u.email,
+                                createdAt: u.createdAt,
+                                twitterUsername: u.twitterUsername,
+                                company: u.company,
+                                location: u.location,
+                                websiteUrl: u.websiteUrl,
+                                repositories: u.repositories
+                            }
+                        }
+                    }
+                ];
+            }
+            if (body.query.includes('UserDetailsCalendar')) {
+                return [
+                    200,
+                    {
+                        data: {
+                            user: {
+                                contributionsCollection: {
+                                    contributionCalendar: u.contributionsCollection.contributionCalendar
+                                }
+                            }
+                        }
+                    }
+                ];
+            }
+            if (body.query.includes('UserDetailsYears')) {
+                return [200, {data: {user: {contributionsCollection: {contributionYears: [2019, 2020]}}}}];
+            }
+            if (body.query.includes('UserDetailsCounts')) {
+                return [
+                    200,
+                    {
+                        data: {
+                            user: {
+                                repositoriesContributedTo: u.repositoriesContributedTo,
+                                pullRequests: u.pullRequests,
+                                issues: u.issues
+                            }
+                        }
+                    }
+                ];
+            }
+            return [500, {}];
+        });
+
+        const profileDetails = await getProfileDetails('antroll', 'token');
+        // identical result to the combined-query path
+        expect(profileDetails.totalStars).toBe(130);
+        expect(profileDetails.totalPullRequestContributions).toBe(40);
+        expect(profileDetails.totalRepositoryContributions).toBe(30);
+        expect(profileDetails.contributionYears).toEqual([2019, 2020]);
+        expect(profileDetails.contributions).toHaveLength(3);
+    });
+
+    it('merges two half-window calendars when even the calendar alone is rejected', async () => {
+        const resourceLimit = {errors: [{message: 'Resource limits for this query exceeded.'}]};
+        const u = data.data.user;
+        const week = (date: string, count: number) => ({contributionDays: [{date, contributionCount: count}]});
+        mock.onPost('https://api.github.com/graphql').reply(config => {
+            const body = JSON.parse(config.data);
+            const vars = body.variables ?? {};
+            if (body.query.includes('query UserDetails(')) return [200, resourceLimit];
+            if (body.query.includes('UserDetailsCalendar')) {
+                // full trailing-year window (null from/to) rejected; halves pass
+                if (!vars.from) return [200, resourceLimit];
+                const isFirstHalf = new Date(vars.from).getTime() < Date.now() - 200 * 24 * 3600 * 1000;
+                return [
+                    200,
+                    {
+                        data: {
+                            user: {
+                                contributionsCollection: {
+                                    contributionCalendar: {
+                                        weeks: [isFirstHalf ? week('2025-09-01', 4) : week('2026-03-01', 6)]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ];
+            }
+            if (body.query.includes('UserDetailsCore')) {
+                return [
+                    200,
+                    {
+                        data: {
+                            user: {
+                                id: u.id,
+                                name: u.name,
+                                email: u.email,
+                                createdAt: u.createdAt,
+                                twitterUsername: u.twitterUsername,
+                                company: u.company,
+                                location: u.location,
+                                websiteUrl: u.websiteUrl,
+                                repositories: u.repositories
+                            }
+                        }
+                    }
+                ];
+            }
+            if (body.query.includes('UserDetailsYears')) {
+                return [200, {data: {user: {contributionsCollection: {contributionYears: [2025, 2026]}}}}];
+            }
+            if (body.query.includes('UserDetailsCounts')) {
+                return [
+                    200,
+                    {
+                        data: {
+                            user: {
+                                repositoriesContributedTo: u.repositoriesContributedTo,
+                                pullRequests: u.pullRequests,
+                                issues: u.issues
+                            }
+                        }
+                    }
+                ];
+            }
+            return [500, {}];
+        });
+
+        const profileDetails = await getProfileDetails('antfu', 'token');
+        // both half-window days present, in order
+        expect(profileDetails.contributions.map(c => c.contributionCount)).toEqual([4, 6]);
+    });
+
     it('sums stars across every repo page, not just the first 100', async () => {
         const page1 = JSON.parse(JSON.stringify(data));
         page1.data.user.repositories.pageInfo = {endCursor: 'C1', hasNextPage: true};

--- a/tests/github-api/profile-details.test.ts
+++ b/tests/github-api/profile-details.test.ts
@@ -181,6 +181,7 @@ describe('github api for profile details', () => {
         const resourceLimit = {errors: [{message: 'Resource limits for this query exceeded.'}]};
         const u = data.data.user;
         const week = (date: string, count: number) => ({contributionDays: [{date, contributionCount: count}]});
+        const calendarWindows: {from: string; to: string}[] = [];
         mock.onPost('https://api.github.com/graphql').reply(config => {
             const body = JSON.parse(config.data);
             const vars = body.variables ?? {};
@@ -188,6 +189,7 @@ describe('github api for profile details', () => {
             if (body.query.includes('UserDetailsCalendar')) {
                 // full trailing-year window (null from/to) rejected; halves pass
                 if (!vars.from) return [200, resourceLimit];
+                calendarWindows.push({from: vars.from, to: vars.to});
                 const isFirstHalf = new Date(vars.from).getTime() < Date.now() - 200 * 24 * 3600 * 1000;
                 return [
                     200,
@@ -247,6 +249,21 @@ describe('github api for profile details', () => {
         const profileDetails = await getProfileDetails('antfu', 'token');
         // both half-window days present, in order
         expect(profileDetails.contributions.map(c => c.contributionCount)).toEqual([4, 6]);
+
+        // The two windows must be adjacent on a UTC day boundary — a mid-day
+        // seam would put the boundary date into both halves' calendars.
+        expect(calendarWindows).toHaveLength(2);
+        const [w1, w2] = calendarWindows.sort((a, b) => a.from.localeCompare(b.from));
+        expect(new Date(w1.to).getTime() + 1).toBe(new Date(w2.from).getTime());
+        expect(w2.from.endsWith('T00:00:00.000Z')).toBe(true);
+        expect(w1.from.endsWith('T00:00:00.000Z')).toBe(true);
+        // ~1 year covered end to end
+        const spanDays = (new Date(w2.to).getTime() - new Date(w1.from).getTime()) / (24 * 3600 * 1000);
+        expect(spanDays).toBeGreaterThanOrEqual(363);
+        expect(spanDays).toBeLessThanOrEqual(366);
+        // merged daily series has no duplicate dates
+        const dates = profileDetails.contributions.map(c => c.date.toISOString());
+        expect(new Set(dates).size).toBe(dates.length);
     });
 
     it('sums stars across every repo page, not just the first 100', async () => {


### PR DESCRIPTION
## Problem (user report)

`/api/cards/profile-details?username=Antroll` error-cards with `Resource limits for this query exceeded` — the combined UserDetails document (light fields + repos/stars + full trailing-year calendar + contribution counts) trips GitHub's cost estimator for very active accounts. Same estimator behavior as #291/#294, now on the biggest query we make.

## Fix: tiered split, same fields, same shape

1. **Fast path unchanged** — one combined query for ~everyone.
2. On `isResourceLimit`: three parallel cheaper documents — `UserDetailsCore` (light fields + repos/stars page 1), `UserDetailsCalendar` + `UserDetailsYears`, `UserDetailsCounts` — rebuilt into the exact `user` shape the combined query returns, so everything after the cache boundary (star pagination included) is untouched.
3. If even the trailing-year **calendar alone** is rejected (antfu-class): two disjoint half-window calendars, days concatenated into the same daily series.

Diagnosed against the live API: Antroll fails combined, passes at tier 2. gaearon-class passes at tier 2. antfu-class needs tier 3 for the calendar.

## Verified live

- **Antroll: fixed** — 12 contribution years, 370 daily points, all counts (6.8s cold, then cached; production already healed via cache warm-up)
- 2 new tests (tier-2 split merge, tier-3 half-window calendar merge); full suite green

## Known remaining limit

antfu / kentcdodds still fail: `repositoriesContributedTo` is rejected **even queried alone** and has no window parameter to shrink; no same-semantics alternative exists. Those accounts recover when GitHub's side does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub profile loading when contribution-related requests hit GitHub resource limits.
  * Added automatic fallback to retrieve contribution data in smaller requests and seamlessly merge results.
  * Preserves contribution totals and complete, correctly ordered contribution history even when large calendar queries are restricted.

* **Tests**
  * Added Jest coverage for fallback behavior, including split calendar window retries and merged daily contributions with no duplicates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->