### PR TITLE
fix: pin productive-time's collection window to the sampling range

### DIFF
--- a/src/github-api/productive-time.ts
+++ b/src/github-api/productive-time.ts
@@ -30,6 +30,13 @@ const userIdFetcher = (token: string, variables: any) => {
 // We use the authored datetime to calculate productive time: committedDate is
 // rewritten by squash/rebase merges (it becomes the merge-click time), while
 // authoredDate keeps the moment the code was actually written.
+//
+// The contributionsCollection window is pinned to the same since/until range
+// as the history sampling. Two reasons: the repo list should be "repos with
+// commits in the sampled window" (the default trailing-year window listed
+// repos with no commits in the window at all), and the trailing-year
+// collection is what GitHub's cost estimator rejects for very active accounts
+// ("Resource limits for this query exceeded") — the short window passes.
 const fetcher = (token: string, variables: any) => {
     return request(
         {
@@ -37,9 +44,9 @@ const fetcher = (token: string, variables: any) => {
         },
         {
             query: `
-      query ProductiveTime($login: String!,$userId: ID!,$until: GitTimestamp!,,$since: GitTimestamp!) {
+      query ProductiveTime($login: String!,$userId: ID!,$until: GitTimestamp!,$since: GitTimestamp!,$from: DateTime!,$to: DateTime!) {
         user(login: $login) {
-          contributionsCollection{
+          contributionsCollection(from: $from, to: $to){
             commitContributionsByRepository(maxRepositories:50) {
               repository {
                 defaultBranchRef {
@@ -80,7 +87,8 @@ export async function getProductiveTime(
 ): Promise<ProfuctiveTime> {
     // The since/until window shifts with the current date, so it's part of the
     // key — plain commit-date strings are cached, Date-like usage stays outside.
-    const authoredDates = await withDataCache(`v2:pt:${username.toLowerCase()}:${since}:${until}`, async () => {
+    // v3: the collection window is now pinned to since/until (repo list changed).
+    const authoredDates = await withDataCache(`v3:pt:${username.toLowerCase()}:${since}:${until}`, async () => {
         const userIdResponse = await userIdFetcher(token, {
             login: username
         });
@@ -94,7 +102,9 @@ export async function getProductiveTime(
             login: username,
             userId: userId,
             until: until,
-            since: since
+            since: since,
+            from: since,
+            to: until
         });
 
         assertNoGraphQLErrors(res, 'GetProductiveTime failed');


### PR DESCRIPTION
## Found by the every-card resource-limit audit

Sweeping all remaining GraphQL documents for estimator exposure (after #291/#294/#295), productive-time turned out to be **the heaviest document we send**: `commitContributionsByRepository(maxRepositories: 50)` × `history(first: 50)` nested under a **default trailing-year** contributionsCollection. Verified live: rejected 100% for antfu-class accounts, and — consistent with every other case — shrinking page sizes (25×25, 10×50, 25×10) never helps.

Org cards were probed too (microsoft, incl. the remaining `orderBy: STARGAZERS` ones) — all pass; left untouched.

## Fix: align the collection window with the sampling window

The card samples commits in a since/until range, but the collection listing the repos spanned the whole trailing year. Pinning `contributionsCollection(from/to)` to the same range is simultaneously:
- **a correctness fix** — the repo list becomes "repos with commits in the sampled window" (before: top-year repos even with zero commits in the window)
- **the resource-limit fix** — the short window sails under the estimator: antfu samples 51 commits in 3s where the old document was rejected every time

Cache key bumped `v2:pt` → `v3:pt` (repo-list semantics changed). 170 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved productive-time reporting by ensuring contribution data is retrieved for the selected date range.
  * Updated cached contribution data to reflect the corrected date-range behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->