### PR TITLE
perf: raise CDN s-maxage to 48h and Redis fresh default to 12h

### DIFF
--- a/src/const/cache.ts
+++ b/src/const/cache.ts
@@ -1,1 +1,5 @@
-export const CONST_CACHE_CONTROL = 'public, max-age=14400, s-maxage=86400, stale-while-revalidate=604800';
+// s-maxage 48h: cards change slowly and the CDN hit rate directly drives the
+// free-tier budget (every CDN miss is a function invocation plus Redis
+// commands). Browsers/camo still refresh every 4h; SWR keeps a week of
+// serve-stale-while-refreshing on top.
+export const CONST_CACHE_CONTROL = 'public, max-age=14400, s-maxage=172800, stale-while-revalidate=604800';

--- a/src/utils/data-cache.ts
+++ b/src/utils/data-cache.ts
@@ -18,7 +18,10 @@
 
 import {AsyncLocalStorage} from 'async_hooks';
 
-const FRESH_SECONDS_DEFAULT = 6 * 60 * 60; // serve without re-fetching
+// 12h: with the CDN already serving most viewers up-to-48h-old cards, a
+// shorter Redis fresh window buys little visible freshness while doubling the
+// GitHub refresh traffic. Halving that traffic is a free-tier budget lever.
+const FRESH_SECONDS_DEFAULT = 12 * 60 * 60; // serve without re-fetching
 const RETENTION_SECONDS_DEFAULT = 7 * 24 * 60 * 60; // Redis EX — stale kept as a rate-limit fallback
 const KV_TIMEOUT_MS = 1500; // never let a slow Redis block a card render
 

--- a/tests/utils/data-cache.test.ts
+++ b/tests/utils/data-cache.test.ts
@@ -62,7 +62,7 @@ describe('withDataCache', () => {
     });
 
     it('re-fetches when the cached value is stale', async () => {
-        const staleAt = Date.now() - 7 * 60 * 60 * 1000; // older than the 6h fresh window
+        const staleAt = Date.now() - 13 * 60 * 60 * 1000; // older than the 12h fresh window
         fetchSpy
             .mockResolvedValueOnce(envelopeResponse(staleAt, 'stale'))
             .mockResolvedValueOnce({ok: true, json: async () => ({})} as Response);
@@ -71,7 +71,7 @@ describe('withDataCache', () => {
     });
 
     it('serves the stale value when the fetcher fails (rate limited)', async () => {
-        const staleAt = Date.now() - 7 * 60 * 60 * 1000;
+        const staleAt = Date.now() - 13 * 60 * 60 * 1000;
         fetchSpy.mockResolvedValueOnce(envelopeResponse(staleAt, 'stale'));
         const fetcher = jest.fn().mockRejectedValue(new Error('rate limited'));
         await expect(withDataCache('k', fetcher)).resolves.toBe('stale');
@@ -138,7 +138,7 @@ describe('runWithCacheStats', () => {
     });
 
     it('reports stale when a fallback copy was served', async () => {
-        const staleAt = Date.now() - 7 * 60 * 60 * 1000;
+        const staleAt = Date.now() - 13 * 60 * 60 * 1000;
         fetchSpy.mockResolvedValue(envelopeResponse(staleAt, 'stale'));
         const {cacheStatus} = await runWithCacheStats(async () => {
             await withDataCache('a', jest.fn().mockRejectedValue(new Error('rate limited')));


### PR DESCRIPTION
Two one-line free-tier budget levers (user-approved):

- **CDN `s-maxage` 24h → 48h** — every CDN miss is a function invocation + Redis commands; cards change slowly and SWR already keeps a week of serve-stale-while-refreshing on top. Browser/camo `max-age` stays 4h.
- **Redis default fresh window 6h → 12h** — halves GitHub refresh traffic for current-year/profile/repos/productive data. With viewers already seeing up-to-48h-old CDN copies, the shorter window bought no visible freshness. Past-year windows (90d jittered, #293) unaffected.

Tests updated for the new default window; suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Extended cache freshness from 6 hours to 12 hours.
  * Increased shared cache duration from 24 to 48 hours.
  * Retained stale-content support for up to 7 days while refreshed data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->