### PR TITLE
feat: per-instance GitHub concurrency gate + demo-page card staggering

### DIFF
--- a/api/pages/demo.html
+++ b/api/pages/demo.html
@@ -382,77 +382,79 @@
                         ⚙️ Customize <span class="chev" aria-hidden="true">▾</span>
                     </button>
                     <div class="controls-body" id="controlsBody">
-                    <div class="field">
-                        <label for="username">GitHub username / organization</label>
-                        <input id="username" name="username" value="vn7n24fzkq" required />
-                    </div>
-
-                    <div class="row">
                         <div class="field">
-                            <label for="theme">Theme</label>
-                            <select id="theme" name="theme"></select>
+                            <label for="username">GitHub username / organization</label>
+                            <input id="username" name="username" value="vn7n24fzkq" required />
                         </div>
+
+                        <div class="row">
+                            <div class="field">
+                                <label for="theme">Theme</label>
+                                <select id="theme" name="theme"></select>
+                            </div>
+                            <div class="field">
+                                <label for="animation">Animation</label>
+                                <select id="animation" name="animation">
+                                    <option value="">none</option>
+                                    <option value="fade">fade</option>
+                                    <option value="rise">rise</option>
+                                    <option value="draw">draw</option>
+                                    <option value="stagger">stagger</option>
+                                    <option value="load">load</option>
+                                    <option value="sequence">sequence</option>
+                                    <option value="tint">tint</option>
+                                    <option value="rgb">rgb</option>
+                                    <option value="rgb-soft">rgb-soft</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <div class="row">
+                            <div class="field">
+                                <label for="duration">Duration (s)</label>
+                                <input
+                                    id="duration"
+                                    name="duration"
+                                    type="number"
+                                    min="0.2"
+                                    max="10"
+                                    step="0.1"
+                                    placeholder="default"
+                                />
+                            </div>
+                            <div class="field">
+                                <label for="utcOffset">UTC offset</label>
+                                <input
+                                    id="utcOffset"
+                                    name="utcOffset"
+                                    type="number"
+                                    min="-12"
+                                    max="14"
+                                    step="1"
+                                    value="0"
+                                />
+                            </div>
+                        </div>
+
                         <div class="field">
-                            <label for="animation">Animation</label>
-                            <select id="animation" name="animation">
-                                <option value="">none</option>
-                                <option value="fade">fade</option>
-                                <option value="rise">rise</option>
-                                <option value="draw">draw</option>
-                                <option value="stagger">stagger</option>
-                                <option value="load">load</option>
-                                <option value="sequence">sequence</option>
-                                <option value="tint">tint</option>
-                                <option value="rgb">rgb</option>
-                                <option value="rgb-soft">rgb-soft</option>
-                            </select>
+                            <label for="name">Display name (profile card)</label>
+                            <input id="name" name="name" placeholder="default: login (name)" />
                         </div>
-                    </div>
 
-                    <div class="row">
                         <div class="field">
-                            <label for="duration">Duration (s)</label>
-                            <input
-                                id="duration"
-                                name="duration"
-                                type="number"
-                                min="0.2"
-                                max="10"
-                                step="0.1"
-                                placeholder="default"
-                            />
+                            <label for="exclude">Exclude languages (comma separated)</label>
+                            <input id="exclude" name="exclude" placeholder="e.g. html,css" />
                         </div>
-                        <div class="field">
-                            <label for="utcOffset">UTC offset</label>
-                            <input
-                                id="utcOffset"
-                                name="utcOffset"
-                                type="number"
-                                min="-12"
-                                max="14"
-                                step="1"
-                                value="0"
-                            />
-                        </div>
-                    </div>
 
-                    <div class="field">
-                        <label for="name">Display name (profile card)</label>
-                        <input id="name" name="name" placeholder="default: login (name)" />
-                    </div>
+                        <details class="colors">
+                            <summary>Custom colours</summary>
+                            <div class="colorgrid" id="colorgrid"></div>
+                            <p class="hint">Leave a colour unticked to use the theme's default.</p>
+                        </details>
 
-                    <div class="field">
-                        <label for="exclude">Exclude languages (comma separated)</label>
-                        <input id="exclude" name="exclude" placeholder="e.g. html,css" />
-                    </div>
-
-                    <details class="colors">
-                        <summary>Custom colours</summary>
-                        <div class="colorgrid" id="colorgrid"></div>
-                        <p class="hint">Leave a colour unticked to use the theme's default.</p>
-                    </details>
-
-                    <button class="btn primary" id="copyAll" type="button" style="width: 100%">📋 Copy all Markdown</button>
+                        <button class="btn primary" id="copyAll" type="button" style="width: 100%">
+                            📋 Copy all Markdown
+                        </button>
                     </div>
                 </form>
 
@@ -605,7 +607,8 @@
                         return;
                     }
                     var bust = Date.now(); // cache-buster so animations replay on re-render
-                    CARDS.forEach(function (c) {
+                    var pending = []; // stagger queue — see below
+                    CARDS.forEach(function (c, idx) {
                         var endpoint = c[0],
                             label = c[1],
                             wide = c[2];
@@ -616,7 +619,12 @@
                         var img = document.createElement('img');
                         img.loading = 'lazy';
                         img.alt = label + ' card preview';
-                        img.src = cardUrl(endpoint, true) + '&_t=' + bust;
+                        // Stagger the five requests: for an uncached heavyweight
+                        // account, firing them simultaneously can burst dozens of
+                        // parallel GitHub queries server-side and trip secondary
+                        // rate limits. Each card starts when the previous one
+                        // settles (or after a short timeout).
+                        pending.push({img: img, src: cardUrl(endpoint, true) + '&_t=' + bust});
                         fig.appendChild(img);
 
                         var meta = document.createElement('div');
@@ -637,6 +645,24 @@
                         card.appendChild(meta);
                         cardsEl.appendChild(card);
                     });
+
+                    // Kick off the staggered loads: next card starts when the
+                    // previous settles, with a 4s safety timeout so one slow
+                    // card never stalls the rest.
+                    (function loadNext(i) {
+                        if (i >= pending.length) return;
+                        var item = pending[i];
+                        var advanced = false;
+                        var advance = function () {
+                            if (advanced) return;
+                            advanced = true;
+                            loadNext(i + 1);
+                        };
+                        item.img.addEventListener('load', advance);
+                        item.img.addEventListener('error', advance);
+                        setTimeout(advance, 4000);
+                        item.img.src = item.src;
+                    })(0);
                 }
 
                 function copyText(text, btn) {

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -40,7 +40,47 @@ export function assertNoGraphQLErrors(res: any, fallbackMessage: string): void {
     }
 }
 
-export default function request(header: any, data: any): AxiosPromise<any> {
+// ---- per-instance concurrency gate ----
+// A cold heavy account renders 5 cards at once (README embeds / the demo page
+// load all five images simultaneously), each firing chunks of parallel
+// per-year queries plus fallbacks — bursts of 25-40 concurrent GraphQL calls
+// trip GitHub's SECONDARY rate limit (403 with points to spare; observed in
+// production 2026-07-17). Capping concurrent GitHub calls per lambda instance
+// keeps the burst shape polite: excess calls queue for a moment instead of
+// turning into an hour of 403s. Fluid routes many requests onto one instance,
+// so the gate covers cross-card and cross-request bursts alike.
+const MAX_CONCURRENT_GITHUB_CALLS = 8;
+let activeGithubCalls = 0;
+const githubCallWaiters: Array<() => void> = [];
+
+async function acquireGithubSlot(): Promise<void> {
+    if (activeGithubCalls < MAX_CONCURRENT_GITHUB_CALLS) {
+        activeGithubCalls += 1;
+        return;
+    }
+    await new Promise<void>(resolve => githubCallWaiters.push(resolve));
+}
+
+function releaseGithubSlot(): void {
+    const next = githubCallWaiters.shift();
+    if (next) {
+        // hand the slot straight to the next waiter — activeGithubCalls stays put
+        next();
+    } else {
+        activeGithubCalls -= 1;
+    }
+}
+
+export default async function request(header: any, data: any): Promise<any> {
+    await acquireGithubSlot();
+    try {
+        return await rawRequest(header, data);
+    } finally {
+        releaseGithubSlot();
+    }
+}
+
+function rawRequest(header: any, data: any): AxiosPromise<any> {
     // GitHub's API requires a User-Agent header; without it the edge returns 502.
     // Callers can override via `header`, but we provide a sensible default.
     const headersWithUA = {'User-Agent': 'github-profile-summary-cards', ...header};

--- a/tests/utils/request.test.ts
+++ b/tests/utils/request.test.ts
@@ -87,14 +87,31 @@ describe('GitHub concurrency gate', () => {
         }
     });
 
-    it('releases slots when a request fails', async () => {
+    it("hands a failed request's slot to queued waiters under saturation", async () => {
         const mock = new MockAdapter(axios);
-        // 404 is not retried by retry-axios, so the rejection is immediate.
-        mock.onPost('https://api.github.com/graphql').replyOnce(404).onPost().reply(200, {data: {}});
+        // 404 is not retried by retry-axios, so rejections are immediate. The
+        // gate is saturated (8 slow calls), then extra calls QUEUE — two of
+        // them fail once they run. If a failure ever dropped its slot instead
+        // of handing it down, the remaining waiters would deadlock and this
+        // test would time out.
+        let served = 0;
+        mock.onPost('https://api.github.com/graphql').reply(config => {
+            served += 1;
+            const body = JSON.parse(config.data);
+            if (body.query.includes('FAIL')) return [404, {}];
+            return new Promise(resolve => setTimeout(() => resolve([200, {data: {ok: true}}]), 15));
+        });
         try {
-            await expect(request({}, {query: '{x}'})).rejects.toThrow();
-            // the failed call must have released its slot — the next one runs
-            await expect(request({}, {query: '{x}'})).resolves.toBeTruthy();
+            const calls = [
+                ...Array.from({length: 8}, () => request({}, {query: '{slow}'})), // saturate every slot
+                request({}, {query: '{FAIL_1}'}), // queued, then fails
+                request({}, {query: '{FAIL_2}'}), // queued, then fails
+                ...Array.from({length: 4}, () => request({}, {query: '{slow}'})) // queued behind the failures
+            ];
+            const settled = await Promise.allSettled(calls);
+            expect(settled.filter(s => s.status === 'fulfilled')).toHaveLength(12);
+            expect(settled.filter(s => s.status === 'rejected')).toHaveLength(2);
+            expect(served).toBe(14); // every queued call actually ran — no lost slots
         } finally {
             mock.restore();
         }

--- a/tests/utils/request.test.ts
+++ b/tests/utils/request.test.ts
@@ -1,4 +1,6 @@
-import {assertNoGraphQLErrors} from '../../src/utils/request';
+import request, {assertNoGraphQLErrors} from '../../src/utils/request';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
 
 describe('assertNoGraphQLErrors', () => {
     it('does nothing when there are no errors', () => {
@@ -54,6 +56,47 @@ describe('assertNoGraphQLErrors', () => {
         } catch (e: any) {
             expect(e.isResourceLimit).toBe(true);
             expect(e.isRateLimit).toBeUndefined();
+        }
+    });
+});
+
+describe('GitHub concurrency gate', () => {
+    it('caps concurrent GitHub calls at 8 and still completes every request', async () => {
+        const mock = new MockAdapter(axios, {delayResponse: 30});
+        let inFlight = 0;
+        let peak = 0;
+        mock.onPost('https://api.github.com/graphql').reply(() => {
+            inFlight += 1;
+            peak = Math.max(peak, inFlight);
+            return new Promise(resolve =>
+                setTimeout(() => {
+                    inFlight -= 1;
+                    resolve([200, {data: {ok: true}}]);
+                }, 20)
+            );
+        });
+        try {
+            const results = await Promise.all(
+                Array.from({length: 30}, () => request({Authorization: 'bearer t'}, {query: '{x}'}))
+            );
+            expect(results).toHaveLength(30);
+            expect(peak).toBeLessThanOrEqual(8);
+            expect(peak).toBeGreaterThan(1); // the gate parallelizes, not serializes
+        } finally {
+            mock.restore();
+        }
+    });
+
+    it('releases slots when a request fails', async () => {
+        const mock = new MockAdapter(axios);
+        // 404 is not retried by retry-axios, so the rejection is immediate.
+        mock.onPost('https://api.github.com/graphql').replyOnce(404).onPost().reply(200, {data: {}});
+        try {
+            await expect(request({}, {query: '{x}'})).rejects.toThrow();
+            // the failed call must have released its slot — the next one runs
+            await expect(request({}, {query: '{x}'})).resolves.toBeTruthy();
+        } finally {
+            mock.restore();
         }
     });
 });


### PR DESCRIPTION
## Problem (observed in production 2026-07-17)

Testing a cold heavyweight account from the landing page fires **all five cards simultaneously**; each card runs chunks of 5 parallel per-year queries plus resource-limit fallbacks — bursts of 25-40 concurrent GraphQL calls. GitHub answered with **secondary rate limits** (403 `You have exceeded a secondary rate limit` with thousands of points remaining), cascading into error cards. README embeds have the same shape: browsers request all five images at once.

## Fix

1. **`request()` now holds a per-instance semaphore (cap 8)** — excess GitHub calls queue for a moment instead of bursting. Fluid routes many requests onto one instance, so the gate covers cross-card and cross-request bursts alike. Renders under the cap are untouched; a worst-case cold 5-card burst trades a few hundred ms of queueing for not losing the account to 403s.
2. **The demo page staggers its five card loads** — each starts when the previous settles (4s safety timeout), so a landing-page test of an uncached account no longer front-loads the burst.

## Tests

- 30 concurrent `request()` calls: peak in-flight ≤ 8, all 30 complete, still parallel (peak > 1)
- A failed request releases its slot (404, not retried by retry-axios)
- Full suite: 179 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved preview image loading so card images are prepared and loaded sequentially, with a timeout fallback to avoid one slow/failed image stalling others.
  - Stabilized GitHub GraphQL requests by throttling concurrent calls and ensuring the limiter always releases capacity after errors.
- **Tests**
  - Expanded request tests to verify concurrency limits under heavy parallel load and correct queuing/recovery behavior after failures.
- **Style**
  - Reformatted the demo page controls panel and “Copy all Markdown” markup for clearer, more explicit layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->