### PR TITLE
fix: shared profile-fetch deadline — stop FUNCTION_INVOCATION_TIMEOUT loops

### DIFF
--- a/src/const/pagination.ts
+++ b/src/const/pagination.ts
@@ -26,17 +26,22 @@ export const VERCEL_PAGINATION_BUDGET_MS = 12000;
  * @param {number} pagesFetched - How many pages have been fetched so far.
  * @param {number} [maxPages] - Vercel page budget for this query type.
  * @param {number} [startedAtMs] - Pagination start time; on Vercel, stop once
- *     VERCEL_PAGINATION_BUDGET_MS has elapsed even if pages remain.
+ *     the budget has elapsed even if pages remain.
+ * @param {number} [budgetMs] - Wall-clock budget measured from startedAtMs.
+ *     Callers whose clock starts earlier than the pagination itself (e.g. the
+ *     profile fetch sharing one deadline across fallback chains AND star
+ *     pages) pass a larger overall budget here.
  * @return {boolean} True when the caller should fetch the next page.
  */
 export function shouldFetchNextPage(
     hasNextPage: boolean,
     pagesFetched: number,
     maxPages: number = VERCEL_MAX_REPO_PAGES,
-    startedAtMs?: number
+    startedAtMs?: number,
+    budgetMs: number = VERCEL_PAGINATION_BUDGET_MS
 ): boolean {
     if (!hasNextPage) return false;
     if (!process.env.VERCEL) return true;
-    if (startedAtMs !== undefined && Date.now() - startedAtMs > VERCEL_PAGINATION_BUDGET_MS) return false;
+    if (startedAtMs !== undefined && Date.now() - startedAtMs > budgetMs) return false;
     return pagesFetched < maxPages;
 }

--- a/src/github-api/profile-details.ts
+++ b/src/github-api/profile-details.ts
@@ -1,6 +1,6 @@
 import request, {assertNoGraphQLErrors, GraphQLError} from '../utils/request';
 import {shouldFetchNextPage} from '../const/pagination';
-import {withDataCache} from '../utils/data-cache';
+import {withDataCache, kvGetFlag, kvSetFlag} from '../utils/data-cache';
 
 export class ProfileDetails {
     id: number; // user id
@@ -255,28 +255,45 @@ async function fetchCalendarWeeks(username: string, token: string): Promise<Cale
 
 // Rebuilds the exact `user` object shape of the combined UserDetails query
 // from the three split queries, so the code after the cache boundary doesn't
-// care which path produced it.
-async function fetchUserDetailsSplit(username: string, token: string): Promise<any> {
-    const [coreRes, weeks, yearsRes, countsRes] = await Promise.all([
-        coreFetcher(token, {login: username}),
+// care which path produced it. Star pagination starts as soon as the core
+// query (which owns the first page's cursor) resolves and runs CONCURRENTLY
+// with the calendar/years/counts queries — the split path only exists for
+// very active accounts, exactly the ones with many star pages, and running
+// the two serially is what pushed sindresorhus-class renders past Vercel's
+// 30s kill (killed functions cache nothing, so they never converged).
+async function fetchUserDetailsSplit(
+    username: string,
+    token: string,
+    startedAt: number
+): Promise<{user: any; totalStars: number}> {
+    const corePromise = coreFetcher(token, {login: username});
+    const starsPromise = corePromise.then(coreRes => {
+        assertNoGraphQLErrors(coreRes, 'GetProfileDetails (core) failed');
+        return paginateStars(coreRes.data.data.user.repositories, username, token, startedAt);
+    });
+    const [coreRes, totalStars, weeks, yearsRes, countsRes] = await Promise.all([
+        corePromise,
+        starsPromise,
         fetchCalendarWeeks(username, token),
         contributionYearsFetcher(token, {login: username}),
         countsFetcher(token, {login: username})
     ]);
-    assertNoGraphQLErrors(coreRes, 'GetProfileDetails (core) failed');
     assertNoGraphQLErrors(yearsRes, 'GetProfileDetails (years) failed');
     assertNoGraphQLErrors(countsRes, 'GetProfileDetails (counts) failed');
     const core = coreRes.data.data.user;
     const counts = countsRes.data.data.user;
     return {
-        ...core,
-        contributionsCollection: {
-            contributionCalendar: {weeks},
-            contributionYears: yearsRes.data.data.user.contributionsCollection.contributionYears
+        user: {
+            ...core,
+            contributionsCollection: {
+                contributionCalendar: {weeks},
+                contributionYears: yearsRes.data.data.user.contributionsCollection.contributionYears
+            },
+            repositoriesContributedTo: counts.repositoriesContributedTo,
+            pullRequests: counts.pullRequests,
+            issues: counts.issues
         },
-        repositoriesContributedTo: counts.repositoriesContributedTo,
-        pullRequests: counts.pullRequests,
-        issues: counts.issues
+        totalStars
     };
 }
 
@@ -385,60 +402,95 @@ function expandContributions(cal: CompactProfilePayload['cal']): ProfileContribu
     return cal.counts.map((count, i) => new ProfileContribution(new Date(startMs + i * DAY_MS), count));
 }
 
+// One deadline for the WHOLE profile fetch — the slow-reject of the combined
+// query, the split fallback chain and star pagination all share it. Separate
+// clocks let the phases stack to ~27s and past Vercel's 30s kill (a killed
+// function caches nothing, so the account never converged).
+const PD_FETCH_BUDGET_MS = 20 * 1000;
+
+// Accounts whose combined UserDetails is rejected by GitHub's cost estimator
+// get flagged so subsequent fetches skip straight to the split (the reject
+// itself costs ~6s of the budget).
+const SPLIT_FLAG_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+function splitFlagKey(username: string): string {
+    return `v1:pdx:${username.toLowerCase()}`;
+}
+
+// The main query only covers the first 100 repos; accounts with more were
+// undercounting stars (#164). Keep summing with the lightweight star-only
+// query — unbounded off Vercel, bounded on it. The budget is measured from
+// the profile fetch's start, not the pagination's, so the phases can't stack.
+async function paginateStars(firstPage: any, username: string, token: string, startedAt: number): Promise<number> {
+    let stars: number = firstPage.nodes.reduce(
+        (acc: number, curr: {stargazers: {totalCount: number}}) => acc + curr.stargazers.totalCount,
+        0
+    );
+    let starsCursor: string | null = firstPage.pageInfo?.endCursor ?? null;
+    let starsPages = 1;
+    let starsHasNextPage = shouldFetchNextPage(
+        !!firstPage.pageInfo?.hasNextPage,
+        starsPages,
+        undefined,
+        startedAt,
+        PD_FETCH_BUDGET_MS
+    );
+    while (starsHasNextPage && starsCursor) {
+        const starsRes: any = await starsFetcher(token, {login: username, endCursor: starsCursor});
+        assertNoGraphQLErrors(starsRes, 'GetProfileDetails failed');
+        const repos = starsRes.data.data.user.repositories;
+        stars += repos.nodes.reduce(
+            (acc: number, curr: {stargazers: {totalCount: number}}) => acc + curr.stargazers.totalCount,
+            0
+        );
+        starsCursor = repos.pageInfo?.endCursor ?? null;
+        starsPages += 1;
+        starsHasNextPage = shouldFetchNextPage(
+            !!repos.pageInfo?.hasNextPage,
+            starsPages,
+            undefined,
+            startedAt,
+            PD_FETCH_BUDGET_MS
+        );
+    }
+    return stars;
+}
+
 export async function getProfileDetails(username: string, token: string): Promise<ProfileDetails> {
     // Cache a COMPACT payload per username (see compressProfile). The
     // ProfileDetails instance (with real Date objects) is built after the
     // cache boundary so only plain JSON is ever stored.
     const compact = await withDataCache(`v2:pd:${username.toLowerCase()}`, async () => {
-        let fetchedUser: any;
-        try {
-            const res = await fetcher(token, {
-                login: username
-            });
-            assertNoGraphQLErrors(res, 'GetProfileDetails failed');
-            fetchedUser = res.data.data.user;
-        } catch (err) {
-            if (!(err as GraphQLError).isResourceLimit) throw err;
-            // The combined document was rejected for this very active account —
-            // fetch the same fields via three smaller queries instead.
-            fetchedUser = await fetchUserDetailsSplit(username, token);
+        const startedAt = Date.now();
+        let fetchedUser: any = null;
+        let totalStars: number | null = null;
+        const useSplit = await kvGetFlag(splitFlagKey(username));
+        if (!useSplit) {
+            try {
+                const res = await fetcher(token, {
+                    login: username
+                });
+                assertNoGraphQLErrors(res, 'GetProfileDetails failed');
+                fetchedUser = res.data.data.user;
+            } catch (err) {
+                if (!(err as GraphQLError).isResourceLimit) throw err;
+                // Remember the rejection so the next fetch skips the ~6s
+                // slow-reject and goes straight to the split.
+                void kvSetFlag(splitFlagKey(username), SPLIT_FLAG_TTL_SECONDS);
+            }
         }
-        let stars: number = fetchedUser.repositories.nodes.reduce(
-            (acc: number, curr: {stargazers: {totalCount: number}}) => acc + curr.stargazers.totalCount,
-            0
-        );
-
-        // The main query only covers the first 100 repos; accounts with more were
-        // undercounting stars (#164). Keep summing with the lightweight star-only
-        // query — unbounded off Vercel, bounded on it (see src/const/pagination.ts).
-        const starsStartedAt = Date.now();
-        let starsCursor: string | null = fetchedUser.repositories.pageInfo?.endCursor ?? null;
-        let starsPages = 1;
-        let starsHasNextPage = shouldFetchNextPage(
-            !!fetchedUser.repositories.pageInfo?.hasNextPage,
-            starsPages,
-            undefined,
-            starsStartedAt
-        );
-        while (starsHasNextPage && starsCursor) {
-            const starsRes: any = await starsFetcher(token, {login: username, endCursor: starsCursor});
-            assertNoGraphQLErrors(starsRes, 'GetProfileDetails failed');
-            const repos = starsRes.data.data.user.repositories;
-            stars += repos.nodes.reduce(
-                (acc: number, curr: {stargazers: {totalCount: number}}) => acc + curr.stargazers.totalCount,
-                0
-            );
-            starsCursor = repos.pageInfo?.endCursor ?? null;
-            starsPages += 1;
-            starsHasNextPage = shouldFetchNextPage(
-                !!repos.pageInfo?.hasNextPage,
-                starsPages,
-                undefined,
-                starsStartedAt
-            );
+        if (fetchedUser === null) {
+            // Rejected now or flagged earlier — same fields via three smaller
+            // queries, with star pagination running concurrently.
+            const split = await fetchUserDetailsSplit(username, token, startedAt);
+            fetchedUser = split.user;
+            totalStars = split.totalStars;
+        }
+        if (totalStars === null) {
+            totalStars = await paginateStars(fetchedUser.repositories, username, token, startedAt);
         }
 
-        return compressProfile(fetchedUser, stars);
+        return compressProfile(fetchedUser, totalStars);
     });
 
     const {core} = compact;

--- a/src/utils/data-cache.ts
+++ b/src/utils/data-cache.ts
@@ -254,6 +254,31 @@ export async function primeDataCache(keys: string[]): Promise<PrimedReads> {
     return primed;
 }
 
+/**
+ * Reads a boolean flag key. Breaker-aware and fail-open (a KV problem reads
+ * as "flag not set").
+ *
+ * @param {string} key - The flag key.
+ * @return {Promise<boolean>} True when the flag is set.
+ */
+export async function kvGetFlag(key: string): Promise<boolean> {
+    if (!kvConfigured() || !isKvHealthy()) return false;
+    const read = await kvGet<boolean>(key);
+    return read.kind === 'hit';
+}
+
+/**
+ * Sets a boolean flag key with a TTL. Best-effort, fire-and-forget friendly.
+ *
+ * @param {string} key - The flag key.
+ * @param {number} ttlSeconds - Redis EX for the flag.
+ * @return {Promise<void>} Resolves when the write settles.
+ */
+export async function kvSetFlag(key: string, ttlSeconds: number): Promise<void> {
+    if (!kvConfigured() || !isKvHealthy()) return;
+    await kvSet(key, {at: Date.now(), data: true}, ttlSeconds);
+}
+
 // In-flight coalescing: identical keys requested concurrently (Fluid serves
 // many requests per instance) share one lookup+fetch instead of stampeding.
 const inflight = new Map<string, Promise<unknown>>();

--- a/tests/const/pagination.test.ts
+++ b/tests/const/pagination.test.ts
@@ -31,3 +31,17 @@ describe('shouldFetchNextPage', () => {
         expect(shouldFetchNextPage(true, 1, undefined, exhausted)).toBe(true);
     });
 });
+
+describe('shouldFetchNextPage custom budget', () => {
+    afterEach(() => {
+        delete process.env.VERCEL;
+    });
+
+    it('honors a caller-supplied budget larger than the default', () => {
+        process.env.VERCEL = '1';
+        const startedAt = Date.now() - 15_000; // past the 12s default
+        expect(shouldFetchNextPage(true, 1, undefined, startedAt)).toBe(false); // default budget
+        expect(shouldFetchNextPage(true, 1, undefined, startedAt, 20_000)).toBe(true); // pd budget
+        expect(shouldFetchNextPage(true, 1, undefined, Date.now() - 21_000, 20_000)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Production regression found while observing v0.11.4

`profile-details?username=sindresorhus` returned **504 FUNCTION_INVOCATION_TIMEOUT**. Chain: GitHub *newly* rejects his combined UserDetails query (the reject itself takes ~6s) → #295's split fallback adds ~8s → star pagination (1,129 repos ≈ 11 pages) then starts **its own fresh 12s clock** → phases stack to ~27s locally, past Vercel's 30s kill. A killed function caches nothing and never reaches serve-stale, so the account loops on 504 at every refresh. (#299's v2 key bump surfaced this — the old v1 cache had been masking that GitHub started rejecting his combined query.)

## Fix — one budget, three changes

1. **Single 20s deadline** for the whole profile fetch, shared by the slow-reject, the split chain and star pagination (`shouldFetchNextPage` gains a caller-supplied `budgetMs`)
2. **Rejection flag** (`v1:pdx`, 30d): estimator-rejected accounts skip the ~6s slow-reject on subsequent fetches
3. **Concurrent star pagination** in the split path (runs alongside calendar/years/counts instead of after)

## Measured (sindresorhus, fully cold, VERCEL=1)

| | before | after |
|---|---|---|
| cold incl. slow-reject | ~27s → **504 on Vercel** | **20.8s → completes & caches** |
| flagged refresh | n/a | 21.0s, more star pages fit the budget |

Known tradeoff: stars for 1,000+-repo estimator-rejected accounts may be slightly bounded (existing bounded-pagination semantics — sindresorhus reads ~93% of true stars until refreshes catch up). A REST parallel-pagination follow-up (separate quota pool, numeric pages parallelize) can restore full precision and cut ~15s more.

191 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Profile details now load calendar, statistics, and star data more efficiently in parallel.
  * Pagination can continue within a configurable time budget, improving results for larger profiles.

* **Bug Fixes**
  * Profile requests that encounter resource limits now automatically use a fallback approach on future requests.
  * Added resilient caching for fallback preferences, including safe behavior when caching is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->