### PR TITLE
fix: request-scoped clock for every wall-clock budget (504 root fix)

### DIFF
--- a/api/utils/error-reporter.ts
+++ b/api/utils/error-reporter.ts
@@ -32,7 +32,7 @@ function ensureInit(): boolean {
 const KNOWN_ERROR_PATTERNS = [
     /rate limit/i, // GitHub primary/secondary rate limiting (GA: rate_limited)
     /resource limits/i, // cost-estimator rejections (GitHub-side, tracked)
-    /timed out before all years/i, // our own 12s budget throw (converges via cache)
+    /timed out before/i, // our own budget throws (converge via cache)
     /no more github_token/i, // both tokens exhausted — a rate-limit symptom
     /could not resolve/i, // bad username (GA: not_found)
     /not found/i

--- a/api/utils/handle-card.ts
+++ b/api/utils/handle-card.ts
@@ -3,7 +3,7 @@ import {getErrorMsgCard} from './error-card';
 import {reportUnexpectedError, shipErrorRecord} from './error-reporter';
 import {waitUntil} from '@vercel/functions';
 import {sendAnalytics, resolveSource} from '../../src/utils/analytics';
-import {runWithCacheStats} from '../../src/utils/data-cache';
+import {runWithCacheStats, runWithRequestClock} from '../../src/utils/data-cache';
 import {CONST_CACHE_CONTROL} from '../../src/const/cache';
 import {resolveThemeName, parseThemeColorOverride, ThemeColorOverride} from '../../src/const/theme';
 import {parseAnimation, applyAnimation} from '../../src/utils/animation';
@@ -88,50 +88,52 @@ export async function handleCard(
     const source = resolveSource(req.query.source, String(req.headers['user-agent'] ?? ''));
 
     try {
-        let tokenIndex = 0;
-        let token = getGitHubToken(tokenIndex);
-        // Rotate through the configured tokens until one succeeds or getGitHubToken
-        // throws (no token at the next index).
-        while (true) {
-            try {
-                // Collect the data-cache outcome of this render so GA gets a
-                // cache_status dimension (fresh / miss / stale / mixed).
-                const {result: cardSVG, cacheStatus} = await runWithCacheStats(() =>
-                    render(username, theme, override, token)
-                );
-                res.setHeader('Content-Type', 'image/svg+xml');
-                res.setHeader('Cache-Control', CONST_CACHE_CONTROL);
-                res.send(applyAnimation(cardSVG, animation, req.query.duration));
-                // Don't block the response on analytics, but keep the invocation
-                // alive until the calls settle — a bare `void` promise gets
-                // frozen with the lambda after res.send and aborts on the next
-                // thaw. Tag the source (demo page vs README embed vs other) for
-                // GA segmentation.
-                waitUntil(
-                    sendAnalytics(
-                        eventName,
-                        {
-                            username,
-                            theme,
-                            source,
-                            cache_status: cacheStatus,
-                            animation: animation ?? 'none',
-                            ...extraAnalytics
-                        },
-                        req.headers
-                    )
-                );
-                return;
-            } catch (err: any) {
-                console.log(err.message);
-                if (isRotatableError(err)) {
-                    tokenIndex += 1;
-                    token = getGitHubToken(tokenIndex);
-                } else {
-                    throw err;
+        await runWithRequestClock(async () => {
+            let tokenIndex = 0;
+            let token = getGitHubToken(tokenIndex);
+            // Rotate through the configured tokens until one succeeds or getGitHubToken
+            // throws (no token at the next index).
+            while (true) {
+                try {
+                    // Collect the data-cache outcome of this render so GA gets a
+                    // cache_status dimension (fresh / miss / stale / mixed).
+                    const {result: cardSVG, cacheStatus} = await runWithCacheStats(() =>
+                        render(username, theme, override, token)
+                    );
+                    res.setHeader('Content-Type', 'image/svg+xml');
+                    res.setHeader('Cache-Control', CONST_CACHE_CONTROL);
+                    res.send(applyAnimation(cardSVG, animation, req.query.duration));
+                    // Don't block the response on analytics, but keep the invocation
+                    // alive until the calls settle — a bare `void` promise gets
+                    // frozen with the lambda after res.send and aborts on the next
+                    // thaw. Tag the source (demo page vs README embed vs other) for
+                    // GA segmentation.
+                    waitUntil(
+                        sendAnalytics(
+                            eventName,
+                            {
+                                username,
+                                theme,
+                                source,
+                                cache_status: cacheStatus,
+                                animation: animation ?? 'none',
+                                ...extraAnalytics
+                            },
+                            req.headers
+                        )
+                    );
+                    return;
+                } catch (err: any) {
+                    console.log(err.message);
+                    if (isRotatableError(err)) {
+                        tokenIndex += 1;
+                        token = getGitHubToken(tokenIndex);
+                    } else {
+                        throw err;
+                    }
                 }
             }
-        }
+        });
     } catch (err: any) {
         // Log the real error for debugging; show only a generic message to clients.
         // Log only a redacted summary — never the raw error object, which for axios

--- a/src/github-api/commits-per-language.ts
+++ b/src/github-api/commits-per-language.ts
@@ -1,5 +1,5 @@
 import request, {assertNoGraphQLErrors, GraphQLError} from '../utils/request';
-import {withDataCache, primeDataCache, jitteredSeconds, PrimedReads} from '../utils/data-cache';
+import {withDataCache, primeDataCache, jitteredSeconds, requestStartedAt, PrimedReads} from '../utils/data-cache';
 
 const DAY = 24 * 60 * 60;
 import {VERCEL_PAGINATION_BUDGET_MS} from '../const/pagination';
@@ -206,7 +206,8 @@ export async function getCommitLanguageAllYears(
 ): Promise<CommitLanguages> {
     const commitLanguages = new CommitLanguages();
     const sortedYears = [...years].sort((a, b) => b - a);
-    const startedAt = Date.now();
+    // Request-scoped clock — see contribution-history.
+    const startedAt = requestStartedAt() ?? Date.now();
 
     // Batch-read every year key with one MGET; a warm render costs a single
     // Redis command instead of one per year.

--- a/src/github-api/profile-details.ts
+++ b/src/github-api/profile-details.ts
@@ -1,6 +1,6 @@
 import request, {assertNoGraphQLErrors, GraphQLError} from '../utils/request';
 import {shouldFetchNextPage} from '../const/pagination';
-import {withDataCache, kvGetFlag, kvSetFlag} from '../utils/data-cache';
+import {withDataCache, kvGetFlag, kvSetFlag, requestStartedAt} from '../utils/data-cache';
 
 export class ProfileDetails {
     id: number; // user id
@@ -461,7 +461,15 @@ export async function getProfileDetails(username: string, token: string): Promis
     // ProfileDetails instance (with real Date objects) is built after the
     // cache boundary so only plain JSON is ever stored.
     const compact = await withDataCache(`v2:pd:${username.toLowerCase()}`, async () => {
-        const startedAt = Date.now();
+        // Measure from the REQUEST start (rotation retries share the deadline);
+        // outside a request context (Action/CLI) fall back to a local clock.
+        const startedAt = requestStartedAt() ?? Date.now();
+        if (process.env.VERCEL && Date.now() - startedAt > PD_FETCH_BUDGET_MS) {
+            // A rotation retry (or an earlier heavy phase) already spent the
+            // budget — fail fast so stale rescue / the error card takes over
+            // instead of a 30s FUNCTION_INVOCATION_TIMEOUT that caches nothing.
+            throw new Error(`Profile fetch for ${username} timed out before completion`);
+        }
         let fetchedUser: any = null;
         let totalStars: number | null = null;
         const useSplit = await kvGetFlag(splitFlagKey(username));

--- a/src/utils/contribution-history.ts
+++ b/src/utils/contribution-history.ts
@@ -13,7 +13,7 @@
 // shared cache with a personal token — it writes the private-inclusive view.
 
 import {getContributionByYear, contributionYearCacheKey} from '../github-api/contributions-by-year';
-import {primeDataCache} from './data-cache';
+import {primeDataCache, requestStartedAt} from './data-cache';
 import {VERCEL_PAGINATION_BUDGET_MS} from '../const/pagination';
 
 // Parallel chunk size for per-year queries: keeps a 15-year account to ~3
@@ -45,7 +45,9 @@ export async function getContributionTotals(
     token: string
 ): Promise<ContributionTotals> {
     const years = [...contributionYears].sort((a, b) => b - a);
-    const startedAt = Date.now();
+    // The budget measures from the request start when available so phases and
+    // rotation retries can't stack separate clocks past the function limit.
+    const startedAt = requestStartedAt() ?? Date.now();
 
     // One MGET for every year key (one billed command) instead of a GET per
     // year — on a warm cache the whole history costs a single Redis command.

--- a/src/utils/data-cache.ts
+++ b/src/utils/data-cache.ts
@@ -62,6 +62,35 @@ interface CacheStats {
 
 const cacheStatsStorage = new AsyncLocalStorage<CacheStats>();
 
+// Request-level clock. Every wall-clock budget in the codebase (profile fetch,
+// contribution history, commit languages) measures from THIS instant rather
+// than from its own phase start: separate clocks let phases stack — and token
+// rotation re-running the whole render DOUBLED them — past Vercel's 30s kill
+// (observed as FUNCTION_INVOCATION_TIMEOUT loops on sindresorhus-class
+// accounts; a killed function caches nothing and never converges).
+const requestStartStorage = new AsyncLocalStorage<number>();
+
+/**
+ * Runs `fn` under a request-scoped clock. handleCard opens this OUTSIDE the
+ * token-rotation loop so retries share the same deadline.
+ *
+ * @param {Function} fn - The whole request work, rotation included.
+ * @return {Promise} Whatever `fn` resolves to.
+ */
+export function runWithRequestClock<T>(fn: () => Promise<T>): Promise<T> {
+    return requestStartStorage.run(Date.now(), fn);
+}
+
+/**
+ * The request's start time, when inside runWithRequestClock (undefined in
+ * Action/CLI contexts — callers fall back to their own clock).
+ *
+ * @return {number|undefined} Epoch ms of the request start.
+ */
+export function requestStartedAt(): number | undefined {
+    return requestStartStorage.getStore();
+}
+
 /**
  * Runs `fn` with a fresh cache-outcome collector attached to the async context.
  *

--- a/tests/utils/data-cache.test.ts
+++ b/tests/utils/data-cache.test.ts
@@ -389,3 +389,21 @@ describe('primeDataCache (batched MGET)', () => {
         expect(fetchSpy).not.toHaveBeenCalled();
     });
 });
+
+describe('runWithRequestClock', () => {
+    it('exposes one start time across nested contexts (rotation retries share it)', async () => {
+        const {runWithRequestClock, requestStartedAt, runWithCacheStats} = require('../../src/utils/data-cache');
+        expect(requestStartedAt()).toBeUndefined(); // Action/CLI: no context
+        await runWithRequestClock(async () => {
+            const first = requestStartedAt();
+            expect(typeof first).toBe('number');
+            // simulate handleCard's per-attempt runWithCacheStats nesting
+            await runWithCacheStats(async () => {
+                expect(requestStartedAt()).toBe(first);
+            });
+            await runWithCacheStats(async () => {
+                expect(requestStartedAt()).toBe(first); // second rotation attempt: same clock
+            });
+        });
+    });
+});


### PR DESCRIPTION
## v0.11.5's deadline was necessary but not sufficient

Production still returned `FUNCTION_INVOCATION_TIMEOUT` for sindresorhus cold renders. Two stacking modes survived:

1. **Token rotation doubles budgets** — the 20s profile deadline was per-attempt, and `handleCard` re-runs the whole render on a rate-limited token: 20s (token 1) + 20s (token 2) > 30s kill. Invisible locally (single token = no rotation).
2. **Cross-phase stacking within one attempt** — stats card = profile fetch (20s budget) + contribution totals (own 12s budget) = 32s worst case.

## Fix

`handleCard` opens a **request-scoped clock** (AsyncLocalStorage) outside the rotation loop; every budget consumer — profile fetch, contribution history, commit languages — measures from it. A rotation retry that finds the budget spent **fails fast**, letting stale rescue or a 5-min-cached error card take over instead of a 504 that caches nothing and loops. Action/CLI paths fall back to per-phase clocks (no Vercel limits there).

Verified: clocked sindresorhus fetch completes locally in 21.3s; nested-context test asserts rotation attempts share one start time. 192 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request timeout handling across profile, contribution, and commit data retrieval.
  * Reduced premature failures during token rotation and retry attempts by using a consistent request time budget.
  * Expanded handling of expected timeout conditions to avoid unnecessary error reporting.
* **Tests**
  * Added coverage to verify consistent timing across retries and nested data operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->