### PR TITLE
perf(cache): compact cly payloads 60% + quiet-deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+# Quiet production deploy: main -> `release` branch -> Vercel, WITHOUT a tag
+# or GitHub Release. Deploys and releases are different events with different
+# audiences — web users get fixes the moment they merge, while GitHub Releases
+# (the Action users' and watchers' notification channel) stay curated and
+# meaningful via manual-release.yml. Use this for hotfixes and internal
+# iterations; use Manual Release when a batch of changes deserves a version.
+name: Deploy (no release)
+
+on:
+    workflow_dispatch:
+
+concurrency:
+    group: manual-release # never race the release workflow on the same branch
+    cancel-in-progress: false
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+
+            - uses: actions/setup-node@v6
+              with:
+                  node-version-file: '.node-version'
+                  cache: 'npm'
+
+            - run: npm ci
+            - run: npm run build
+            - run: npm run package
+
+            - name: Git config
+              run: |
+                  git config --global user.name "github-actions[bot]"
+                  git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+            - name: Publish release branch (Vercel production + action dist)
+              run: |
+                  # Recreate `release` from current main, carrying the freshly built dist/
+                  git checkout -B release
+                  git add dist
+                  git commit -m "deploy: ${GITHUB_SHA}" || echo "No dist changes to commit"
+                  # Pushing to `release` triggers the Vercel production deployment
+                  git push -f origin release

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,29 @@
 # Release Process
 
-This repository ships **two artifacts** from a single `release` branch, published
-together by one manual dispatch:
+This repository ships **two artifacts** from a single `release` branch:
 
-- **Web API** — the SVG service on Vercel (`github-profile-summary-cards.vercel.app`).
-- **GitHub Action** — consumed via `vn7n24fzkq/github-profile-summary-cards@<tag>`.
+-   **Web API** — the SVG service on Vercel (`github-profile-summary-cards.vercel.app`).
+-   **GitHub Action** — consumed via `vn7n24fzkq/github-profile-summary-cards@<tag>`.
+
+## Deploy vs. Release — two different events
+
+A **deploy** puts code in front of web users. A **release** is a versioned,
+user-facing announcement (a tag + GitHub Release — the notification channel
+Action consumers and watchers subscribe to). Coupling them turns every hotfix
+into release noise, so there are two dispatches:
+
+| Workflow                                  | What it does                                                                | When to use                                                               |
+| ----------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| **Deploy (no release)** (`deploy.yml`)    | main → `release` branch → Vercel production. **No tag, no GitHub Release.** | Hotfixes, internal iterations, anything web users should get now          |
+| **Manual Release** (`manual-release.yml`) | Same deploy **plus** tag + GitHub Release with notes                        | A meaningful batch of changes worth announcing — write the notes properly |
+
+Rule of thumb: deploy as often as needed; release when the accumulated changes
+tell a story. Quiet deploys don't bump `package.json` — the next real release
+picks a version covering everything since the last tag.
+
+Note: every production deploy wipes the CDN cache (a cold-start invocation
+surge on the free budget) — batch merges before deploying rather than deploying
+per-merge.
 
 ## Branch model
 
@@ -14,18 +33,24 @@ feature branch ──PR──▶ main ──(Manual Release dispatch)──▶ r
                         └── pushes / PRs only create Vercel PREVIEW deployments
 ```
 
-- **`main`** is the development / integration branch. It runs CI and produces
-  Vercel **preview** deployments only — it never deploys to production.
-- **`release`** is machine-managed. **Never commit to it by hand**; the release
-  workflow force-recreates it from `main` on every release.
-- **`dist/`** (the bundled action) is built in CI and lives on `release` and on
-  tags — not on `main`.
+-   **`main`** is the development / integration branch. It runs CI and produces
+    Vercel **preview** deployments only — it never deploys to production.
+-   **`release`** is machine-managed. **Never commit to it by hand**; the release
+    workflow force-recreates it from `main` on every release.
+-   **`dist/`** (the bundled action) is built in CI and lives on `release` and on
+    tags — not on `main`.
 
 ## One-time setup (already configured)
 
-- Vercel **Production Branch** = `release`
-- **Fluid Compute** enabled on the Vercel project
-- `.github/workflows/manual-release.yml` present on `main`
+-   Vercel **Production Branch** = `release`
+-   **Fluid Compute** enabled on the Vercel project
+-   `.github/workflows/manual-release.yml` present on `main`
+
+## Quiet deploy (no release)
+
+1. Merge into `main` via PRs as usual.
+2. On GitHub: **Actions → Deploy (no release) → Run workflow**.
+3. Verify the Vercel production deployment is `Ready` and spot-check a card.
 
 ## Cutting a release
 
@@ -38,36 +63,36 @@ feature branch ──PR──▶ main ──(Manual Release dispatch)──▶ r
 
 The workflow then:
 
-- checks out `main`, runs `npm ci` → `npm run build` → `npm run package`
-  (produces `dist/`),
-- recreates the `release` branch with the fresh `dist/` and force-pushes it,
-  which **triggers the Vercel production deployment**,
-- creates the git **tag** and a **GitHub Release** with auto-generated notes
-  (`generate_release_notes`) covering commits since the previous tag.
+-   checks out `main`, runs `npm ci` → `npm run build` → `npm run package`
+    (produces `dist/`),
+-   recreates the `release` branch with the fresh `dist/` and force-pushes it,
+    which **triggers the Vercel production deployment**,
+-   creates the git **tag** and a **GitHub Release** with auto-generated notes
+    (`generate_release_notes`) covering commits since the previous tag.
 
 ## Versioning
 
 Versions are chosen manually, following
 [Conventional Commits](https://www.conventionalcommits.org/):
 
-- a `feat:` since the last tag → **minor** bump (`0.7.x` → `0.8.0`)
-- only `fix:` / `chore:` → **patch** bump (`0.8.0` → `0.8.1`)
+-   a `feat:` since the last tag → **minor** bump (`0.7.x` → `0.8.0`)
+-   only `fix:` / `chore:` → **patch** bump (`0.8.0` → `0.8.1`)
 
 Keep `package.json`'s `version` in sync with the tag you dispatch.
 
 ## Verifying a release
 
-- **Vercel** — the new production deployment is `Ready`.
-- **GitHub** — the new tag and Release appear under Releases.
-- **Analytics (optional)** — GA4 → Realtime: request a card and confirm the event
-  arrives. Standard reports lag 24–48h, and events fire only on a cache miss, so
-  the numbers are a lower bound (good for trends).
+-   **Vercel** — the new production deployment is `Ready`.
+-   **GitHub** — the new tag and Release appear under Releases.
+-   **Analytics (optional)** — GA4 → Realtime: request a card and confirm the event
+    arrives. Standard reports lag 24–48h, and events fire only on a cache miss, so
+    the numbers are a lower bound (good for trends).
 
 ## Rollback
 
-- **Fastest:** Vercel dashboard → project → Deployments → **Instant Rollback** to
-  the previous good production deployment.
-- **Code-level:** revert the offending commit(s) on `main`, then cut a new release.
+-   **Fastest:** Vercel dashboard → project → Deployments → **Instant Rollback** to
+    the previous good production deployment.
+-   **Code-level:** revert the offending commit(s) on `main`, then cut a new release.
 
 ## Action consumers
 

--- a/docs/architecture/release-pipeline.md
+++ b/docs/architecture/release-pipeline.md
@@ -1,8 +1,10 @@
 # Release pipeline
 
-One manual dispatch releases **both products** — the Vercel web API and the
-GitHub Action tag — from a single machine-managed `release` branch. See
-[`RELEASE.md`](../../RELEASE.md) for the operational runbook.
+Deploys and releases are **separate events**: `deploy.yml` quietly ships main
+to production (hotfixes, iterations), while `manual-release.yml` does the same
+deploy **plus** a tag and a curated GitHub Release (the Action consumers' and
+watchers' notification channel). Both publish through a single machine-managed
+`release` branch. See [`RELEASE.md`](../../RELEASE.md) for the runbook.
 
 ## Branch model & flow
 
@@ -11,6 +13,12 @@ flowchart LR
     feat[feature branch] -->|"PR: tests + lint required, squash"| main
     main -->|every push| ci[CI + Vercel preview deploy]
 
+    subgraph dw[Deploy workflow - quiet, no version]
+        dbuild["npm ci → build → ncc package dist/"]
+        drecreate["Force-recreate release branch from main + dist/"]
+        dbuild --> drecreate
+    end
+
     subgraph rw[Manual Release workflow - dispatch with tag]
         build["npm ci → build → ncc package dist/"]
         recreate["Force-recreate release branch from main + dist/"]
@@ -18,32 +26,34 @@ flowchart LR
         build --> recreate --> tag
     end
 
+    main --> dbuild
     main --> build
-    recreate -->|push -f release| vercel[Vercel production deploy]
+    drecreate -->|push -f release| vercel[Vercel production deploy]
+    recreate -->|push -f release| vercel
     tag --> consumers["Action consumers pin @tag"]
 ```
 
 ## Guardrails & gotchas
 
-- **`main` ruleset**: PRs required, `tests` + `lint` must be green, no force
-  push; repo admin can bypass for emergency hotfixes.
-- **Release notes pin `previous_tag` explicitly** — `release` is
-  force-recreated every time, so GitHub's automatic previous-tag detection
-  walks back to ancient tags and every changelog looks identical.
-- **After a `vercel rollback`, auto-promotion is paused**: run
-  `vercel promote` on the new deployment after the next release.
-- **Every production deploy wipes the CDN cache** — the Redis data cache
-  absorbs the cold start.
-- **Vercel's runtime cannot `require()` ESM-only packages** even on Node 24
-  (caused the #275 outage) — verify dependency changes on a preview
-  deployment; local tests passing is not enough.
+-   **`main` ruleset**: PRs required, `tests` + `lint` must be green, no force
+    push; repo admin can bypass for emergency hotfixes.
+-   **Release notes pin `previous_tag` explicitly** — `release` is
+    force-recreated every time, so GitHub's automatic previous-tag detection
+    walks back to ancient tags and every changelog looks identical.
+-   **After a `vercel rollback`, auto-promotion is paused**: run
+    `vercel promote` on the new deployment after the next release.
+-   **Every production deploy wipes the CDN cache** — the Redis data cache
+    absorbs the cold start.
+-   **Vercel's runtime cannot `require()` ESM-only packages** even on Node 24
+    (caused the #275 outage) — verify dependency changes on a preview
+    deployment; local tests passing is not enough.
 
 ## Environments
 
-| Environment | Branch | GitHub token | Notes |
-|---|---|---|---|
-| Production | `release` | Machine account (+ owner PAT fallback) | Domain: github-profile-summary-cards.vercel.app |
-| Preview | any push / PR | Owner PAT | Per-deployment URLs, protected by Vercel auth |
-| Development | local `vercel dev` | Owner PAT | `.env.local` (never committed) |
+| Environment | Branch             | GitHub token                           | Notes                                           |
+| ----------- | ------------------ | -------------------------------------- | ----------------------------------------------- |
+| Production  | `release`          | Machine account (+ owner PAT fallback) | Domain: github-profile-summary-cards.vercel.app |
+| Preview     | any push / PR      | Owner PAT                              | Per-deployment URLs, protected by Vercel auth   |
+| Development | local `vercel dev` | Owner PAT                              | `.env.local` (never committed)                  |
 
 Env-var changes only take effect on the **next deployment**.

--- a/src/github-api/commits-per-language.ts
+++ b/src/github-api/commits-per-language.ts
@@ -115,7 +115,35 @@ const fetcher = (token: string, variables: any) => {
 };
 
 function commitLanguageYearCacheKey(username: string, year: number): string {
-    return `v1:cly:${username.toLowerCase()}:${year}`;
+    // v2: compact tuple payload (see compressNodes) — cly keys are the biggest
+    // Redis storage consumer and crossing the free plan's 256MB rejects ALL
+    // writes (observed 2026-07-17).
+    return `v2:cly:${username.toLowerCase()}:${year}`;
+}
+
+// Compact cache payload: [nameWithOwner, langName|null, langColor|null, count]
+// per repo. The repo name is derived from nameWithOwner, and the verbose
+// object shape is rebuilt after the cache boundary — ~60% smaller on the wire.
+type CompactCommitNode = [string, string | null, string | null, number];
+
+function compressNodes(nodes: CommitContributionNode[]): CompactCommitNode[] {
+    return nodes.map(node => [
+        node.repository.nameWithOwner ?? node.repository.name ?? '',
+        node.repository.primaryLanguage?.name ?? null,
+        node.repository.primaryLanguage?.color ?? null,
+        node.contributions.totalCount
+    ]);
+}
+
+function expandNodes(compact: CompactCommitNode[]): CommitContributionNode[] {
+    return compact.map(([nameWithOwner, langName, langColor, count]) => ({
+        repository: {
+            name: nameWithOwner.split('/').pop() ?? nameWithOwner,
+            nameWithOwner,
+            primaryLanguage: langName === null ? null : ({name: langName, color: langColor} as any)
+        },
+        contributions: {totalCount: count}
+    }));
 }
 
 async function fetchCommitContributionsWindow(
@@ -139,15 +167,17 @@ async function getCommitContributionsForYear(
     // Jittered per key (90d ± 15d) so burst-cached keys don't expire together.
     const key = commitLanguageYearCacheKey(username, year);
     const freshSeconds = jitteredSeconds(key, 90 * DAY, 15 * DAY);
-    return withDataCache(
+    const compact = await withDataCache(
         key,
         async () => {
             try {
-                return await fetchCommitContributionsWindow(
-                    username,
-                    token,
-                    `${year}-01-01T00:00:00Z`,
-                    `${year}-12-31T23:59:59Z`
+                return compressNodes(
+                    await fetchCommitContributionsWindow(
+                        username,
+                        token,
+                        `${year}-01-01T00:00:00Z`,
+                        `${year}-12-31T23:59:59Z`
+                    )
                 );
             } catch (err) {
                 if (!(err as GraphQLError).isResourceLimit) throw err;
@@ -173,12 +203,13 @@ async function getCommitContributionsForYear(
                         `${year}-12-31T23:59:59Z`
                     )
                 ]);
-                return [...h1, ...h2];
+                return compressNodes([...h1, ...h2]);
             }
         },
         // Past years are immutable — cache long; the current year refreshes.
         isPastYear ? {freshSeconds, retentionSeconds: freshSeconds + 10 * DAY, primed} : {primed}
     );
+    return expandNodes(compact);
 }
 
 /**


### PR DESCRIPTION
## 1. Storage lever (urgent-ish)

`v1:cly` keys are the biggest Redis consumer — 18k+ keys at ~3KB, growing with the backfill. Crossing Upstash free's 256MB **silently rejects all writes** (observed 2026-07-17: caching died, every render re-fetched, amplifying the token storm). Per-repo nodes now cache as `[nameWithOwner, lang, color, count]` tuples (~60% smaller), rebuilt after the cache boundary — same aggregation, same exclude matching. Key bumped `v1:cly` → `v2:cly`; the superseded generation gets deleted at deploy time (schema-bump lesson: dead keys at 256MB break everything).

The fail-open path exercises compress→expand on every existing test, so the round-trip is covered by the whole suite (192 green).

## 2. Deploy ≠ Release

Seven public v0.11.x releases in one day made the Releases channel noisy. New `deploy.yml` ships main → `release` branch → Vercel production **without a tag or GitHub Release**; `manual-release.yml` remains for curated versioned releases. `RELEASE.md` + the architecture doc describe when to use which. This PR will itself ship via the new quiet path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an on-demand deployment option for publishing production updates without creating a formal release.
  * Production deployments now follow a controlled process that helps prevent conflicting deployments.

* **Documentation**
  * Clarified the differences between deployments and releases.
  * Added guidance for versioning, verification, rollback, cache behavior, and release procedures.
  * Updated the release pipeline overview with current workflow diagrams and safeguards.

* **Performance**
  * Improved caching efficiency for GitHub contribution data, reducing stored data size while preserving existing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->