### PR TITLE
feat(api): spread card traffic across the token pool; redact backing account

### DIFF
--- a/api/utils/github-token-updater.ts
+++ b/api/utils/github-token-updater.ts
@@ -1,3 +1,17 @@
+// Returns the env var name a given token index resolves from: GITHUB_TOKEN_<n>
+// when set, with GITHUB_TOKEN as the index-0 fallback. Safe to log — it names
+// the slot, never the token value or the account behind it.
+export const getGitHubTokenName = function (index: number): string {
+    const tokenName = `GITHUB_TOKEN_${index}`;
+    if (process.env[tokenName]) {
+        return tokenName;
+    }
+    if (index === 0 && process.env.GITHUB_TOKEN) {
+        return 'GITHUB_TOKEN';
+    }
+    return tokenName;
+};
+
 export const getGitHubToken = function (index: number): string {
     if (isNaN(index)) {
         throw new Error('Token index must be a number');
@@ -10,12 +24,17 @@ export const getGitHubToken = function (index: number): string {
         throw new Error(`No more GITHUB_TOKEN can be used (Index: ${index})`);
     }
 
-    // Explicitly determine which token source is used for logging
-    const source = process.env[tokenName]
-        ? tokenName
-        : index === 0 && process.env.GITHUB_TOKEN
-          ? 'GITHUB_TOKEN'
-          : 'Unknown';
-    console.log(`Using token source: ${source}`);
+    console.log(`Using token source: ${getGitHubTokenName(index)}`);
     return token;
+};
+
+// Number of consecutively configured tokens starting from index 0. Tokens must
+// be contiguous (GITHUB_TOKEN/GITHUB_TOKEN_0, GITHUB_TOKEN_1, ...) — a gap ends
+// the count, matching how rotation walks the pool.
+export const getGitHubTokenCount = function (): number {
+    let count = 0;
+    while (process.env[`GITHUB_TOKEN_${count}`] || (count === 0 && process.env.GITHUB_TOKEN)) {
+        count += 1;
+    }
+    return count;
 };

--- a/api/utils/handle-card.ts
+++ b/api/utils/handle-card.ts
@@ -1,4 +1,4 @@
-import {getGitHubToken} from './github-token-updater';
+import {getGitHubToken, getGitHubTokenCount, getGitHubTokenName} from './github-token-updater';
 import {getErrorMsgCard} from './error-card';
 import {reportUnexpectedError, shipErrorRecord} from './error-reporter';
 import {waitUntil} from '@vercel/functions';
@@ -28,11 +28,32 @@ function isRotatableError(err: any): boolean {
     return status === 401 || status === 403 || status === 429 || err?.isRateLimit === true;
 }
 
+// GitHub's rate-limit errors name the account behind the token ("API rate
+// limit already exceeded for user ID ..."). That identity has no business in
+// logs or error records — the token slot name (GITHUB_TOKEN_n) says everything
+// operations needs — so scrub it everywhere the message travels.
+export function redactBackingAccount(message: string): string {
+    return message.replace(/user ID \d+/gi, 'the backing account');
+}
+
+// Pin each username to a deterministic starting token so load spreads across
+// the whole pool. With sequential rotation, token 0 takes every request until
+// its account's hourly GraphQL quota dies while the others idle — spreading by
+// username burns the pool evenly and roughly multiplies time-to-exhaustion by
+// the pool size. djb2 over the lowercased login.
+export function tokenPoolStartIndex(username: string, tokenCount: number): number {
+    let hash = 5381;
+    const login = username.toLowerCase();
+    for (let i = 0; i < login.length; i++) {
+        hash = ((hash << 5) + hash + login.charCodeAt(i)) | 0;
+    }
+    return Math.abs(hash) % tokenCount;
+}
+
 // Classify an internal error into a type (GA dimension) + a generic user-facing
-// message. The raw error (e.g. "API rate limit already exceeded for user ID
-// 20241522") can leak the backing account/implementation, so it's logged
-// server-side but never shown on the card — the card only ever shows one of
-// these safe, actionable messages.
+// message. The raw error can leak the backing account/implementation, so it's
+// redacted and logged server-side but never shown on the card — the card only
+// ever shows one of these safe, actionable messages.
 function classifyError(err: any): {type: string; message: string} {
     const raw = String(err?.message ?? '').toLowerCase();
     const status = err?.response?.status;
@@ -89,10 +110,15 @@ export async function handleCard(
 
     try {
         await runWithRequestClock(async () => {
-            let tokenIndex = 0;
+            // Zero configured tokens keeps the old behavior: the first
+            // getGitHubToken(0) call throws the canonical "No more GITHUB_TOKEN"
+            // error before any render is attempted.
+            const tokenCount = Math.max(1, getGitHubTokenCount());
+            let attempts = 0;
+            let tokenIndex = tokenPoolStartIndex(username, tokenCount);
             let token = getGitHubToken(tokenIndex);
-            // Rotate through the configured tokens until one succeeds or getGitHubToken
-            // throws (no token at the next index).
+            // Rotate through the configured tokens (wrapping around the pool)
+            // until one succeeds or every token has been tried.
             while (true) {
                 try {
                     // Collect the data-cache outcome of this render so GA gets a
@@ -124,9 +150,17 @@ export async function handleCard(
                     );
                     return;
                 } catch (err: any) {
-                    console.log(err.message);
+                    console.log(
+                        `${getGitHubTokenName(tokenIndex)} failed: ${redactBackingAccount(String(err?.message ?? 'unknown'))}`
+                    );
                     if (isRotatableError(err)) {
-                        tokenIndex += 1;
+                        attempts += 1;
+                        if (attempts >= tokenCount) {
+                            // Keep the "No more GITHUB_TOKEN" phrasing — classifyError
+                            // maps it to the rate_limited card message.
+                            throw new Error('No more GITHUB_TOKEN can be used (all configured tokens failed)');
+                        }
+                        tokenIndex = (tokenIndex + 1) % tokenCount;
                         token = getGitHubToken(tokenIndex);
                     } else {
                         throw err;
@@ -139,6 +173,11 @@ export async function handleCard(
         // Log only a redacted summary — never the raw error object, which for axios
         // failures carries the request config/headers (incl. the Authorization token)
         // and response body.
+        // Scrub the backing account identity in place so every downstream sink
+        // (console, Sentry, Axiom, GA) sees the redacted form.
+        if (typeof err?.message === 'string') {
+            err.message = redactBackingAccount(err.message);
+        }
         const {type: errorType, message} = classifyError(err);
         console.log(`card error [${eventName}] status=${err?.response?.status ?? 'n/a'}: ${err?.message ?? 'unknown'}`);
         // Unexpected classes only — known ones (rate limits, resource limits,

--- a/tests/utils/github-token-updater.test.ts
+++ b/tests/utils/github-token-updater.test.ts
@@ -1,4 +1,4 @@
-import {getGitHubToken} from '../../api/utils/github-token-updater';
+import {getGitHubToken, getGitHubTokenCount, getGitHubTokenName} from '../../api/utils/github-token-updater';
 
 describe('getGitHubToken', () => {
     const original = {...process.env};
@@ -25,5 +25,62 @@ describe('getGitHubToken', () => {
         delete process.env.GITHUB_TOKEN;
         delete process.env.GITHUB_TOKEN_5;
         expect(() => getGitHubToken(5)).toThrow('No more GITHUB_TOKEN');
+    });
+});
+
+describe('getGitHubTokenCount', () => {
+    const original = {...process.env};
+    beforeEach(() => {
+        delete process.env.GITHUB_TOKEN;
+        delete process.env.GITHUB_TOKEN_0;
+        delete process.env.GITHUB_TOKEN_1;
+        delete process.env.GITHUB_TOKEN_2;
+    });
+    afterEach(() => {
+        process.env = {...original};
+    });
+
+    it('returns 0 with nothing configured', () => {
+        expect(getGitHubTokenCount()).toBe(0);
+    });
+
+    it('counts the bare GITHUB_TOKEN as index 0', () => {
+        process.env.GITHUB_TOKEN = 'tok0';
+        expect(getGitHubTokenCount()).toBe(1);
+    });
+
+    it('counts GITHUB_TOKEN plus numbered tokens (the production shape)', () => {
+        process.env.GITHUB_TOKEN = 'tok0';
+        process.env.GITHUB_TOKEN_1 = 'tok1';
+        expect(getGitHubTokenCount()).toBe(2);
+    });
+
+    it('stops at a gap in the numbering', () => {
+        process.env.GITHUB_TOKEN_0 = 'tok0';
+        process.env.GITHUB_TOKEN_2 = 'tok2';
+        expect(getGitHubTokenCount()).toBe(1);
+    });
+});
+
+describe('getGitHubTokenName', () => {
+    const original = {...process.env};
+    afterEach(() => {
+        process.env = {...original};
+    });
+
+    it('prefers the numbered env var when it exists', () => {
+        process.env.GITHUB_TOKEN_0 = 'tok0';
+        expect(getGitHubTokenName(0)).toBe('GITHUB_TOKEN_0');
+    });
+
+    it('falls back to GITHUB_TOKEN for index 0', () => {
+        delete process.env.GITHUB_TOKEN_0;
+        process.env.GITHUB_TOKEN = 'tok0';
+        expect(getGitHubTokenName(0)).toBe('GITHUB_TOKEN');
+    });
+
+    it('names the slot even when unset (for error logs)', () => {
+        delete process.env.GITHUB_TOKEN_3;
+        expect(getGitHubTokenName(3)).toBe('GITHUB_TOKEN_3');
     });
 });

--- a/tests/utils/handle-card.test.ts
+++ b/tests/utils/handle-card.test.ts
@@ -1,0 +1,138 @@
+import {handleCard, redactBackingAccount, tokenPoolStartIndex} from '../../api/utils/handle-card';
+import type {VercelRequest, VercelResponse} from '@vercel/node';
+
+jest.mock('../../src/utils/analytics', () => ({
+    sendAnalytics: jest.fn().mockResolvedValue(undefined),
+    resolveSource: jest.fn().mockReturnValue('other')
+}));
+jest.mock('../../api/utils/error-reporter', () => ({
+    reportUnexpectedError: jest.fn().mockResolvedValue(undefined),
+    shipErrorRecord: jest.fn().mockResolvedValue(undefined)
+}));
+jest.mock('@vercel/functions', () => ({waitUntil: jest.fn()}));
+
+describe('redactBackingAccount', () => {
+    it('replaces the account id in GitHub rate-limit messages', () => {
+        expect(redactBackingAccount('API rate limit already exceeded for user ID 12345.')).toBe(
+            'API rate limit already exceeded for the backing account.'
+        );
+    });
+
+    it('is case-insensitive and replaces every occurrence', () => {
+        expect(redactBackingAccount('USER ID 1 then user id 2')).toBe('the backing account then the backing account');
+    });
+
+    it('leaves unrelated messages untouched', () => {
+        expect(redactBackingAccount('Could not resolve to a User')).toBe('Could not resolve to a User');
+    });
+});
+
+describe('tokenPoolStartIndex', () => {
+    it('is deterministic and stays within the pool', () => {
+        for (const count of [1, 2, 3, 7]) {
+            for (const name of ['octocat', 'torvalds', 'a', 'Some-User_123']) {
+                const idx = tokenPoolStartIndex(name, count);
+                expect(idx).toBe(tokenPoolStartIndex(name, count));
+                expect(idx).toBeGreaterThanOrEqual(0);
+                expect(idx).toBeLessThan(count);
+            }
+        }
+    });
+
+    it('ignores username casing', () => {
+        expect(tokenPoolStartIndex('OctoCat', 2)).toBe(tokenPoolStartIndex('octocat', 2));
+    });
+
+    it('spreads different usernames across the pool', () => {
+        const seen = new Set<number>();
+        for (let c = 97; c <= 122; c++) {
+            seen.add(tokenPoolStartIndex(String.fromCharCode(c), 2));
+        }
+        expect(seen).toEqual(new Set([0, 1]));
+    });
+});
+
+describe('handleCard token rotation', () => {
+    const originalEnv = {...process.env};
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        process.env.GITHUB_TOKEN = 'tok0';
+        process.env.GITHUB_TOKEN_1 = 'tok1';
+        delete process.env.GITHUB_TOKEN_2;
+    });
+
+    afterEach(() => {
+        process.env = {...originalEnv};
+    });
+
+    const makeReq = (username: string) => ({query: {username}, headers: {}}) as unknown as VercelRequest;
+
+    const makeRes = () => {
+        const res: any = {
+            headers: {} as Record<string, string>,
+            body: undefined as unknown,
+            setHeader(name: string, value: string) {
+                this.headers[name] = value;
+            },
+            send(body: unknown) {
+                this.body = body;
+            },
+            status: jest.fn().mockReturnThis()
+        };
+        return res as VercelResponse & {body: string; headers: Record<string, string>};
+    };
+
+    const rateLimitError = () => {
+        const err: any = new Error('API rate limit already exceeded for user ID 12345.');
+        err.isRateLimit = true;
+        return err;
+    };
+
+    it('starts at the username-pinned token, not always index 0', async () => {
+        const render = jest.fn().mockResolvedValue('<svg/>');
+        const res = makeRes();
+        const username = 'octocat';
+        await handleCard(makeReq(username), res, 'test_card', render);
+
+        const expectedFirst = tokenPoolStartIndex(username, 2) === 0 ? 'tok0' : 'tok1';
+        expect(render).toHaveBeenCalledTimes(1);
+        expect(render.mock.calls[0][3]).toBe(expectedFirst);
+        expect(res.body).toContain('<svg');
+    });
+
+    it('wraps around the pool when the pinned token is rate limited', async () => {
+        const render = jest.fn().mockRejectedValueOnce(rateLimitError()).mockResolvedValueOnce('<svg/>');
+        const res = makeRes();
+        await handleCard(makeReq('octocat'), res, 'test_card', render);
+
+        expect(render).toHaveBeenCalledTimes(2);
+        const tokensTried = render.mock.calls.map(call => call[3]);
+        expect(new Set(tokensTried)).toEqual(new Set(['tok0', 'tok1']));
+        expect(res.body).toContain('<svg');
+    });
+
+    it('stops after one full lap and renders the rate-limited card', async () => {
+        const render = jest.fn().mockRejectedValue(rateLimitError());
+        const res = makeRes();
+        await handleCard(makeReq('octocat'), res, 'test_card', render);
+
+        // Exactly one attempt per configured token — no third lap.
+        expect(render).toHaveBeenCalledTimes(2);
+        expect(res.body).toContain('rate limited');
+        expect(res.body).not.toContain('12345');
+    });
+
+    it('does not rotate on non-rotatable errors and never leaks the account id', async () => {
+        const err: any = new Error('boom for user ID 98765');
+        const render = jest.fn().mockRejectedValue(err);
+        const res = makeRes();
+        await handleCard(makeReq('octocat'), res, 'test_card', render);
+
+        expect(render).toHaveBeenCalledTimes(1);
+        expect(res.body).toContain('temporarily unavailable');
+        expect(res.body).not.toContain('98765');
+        // The in-place redaction cleans the message before it reaches any sink.
+        expect(err.message).toBe('boom for the backing account');
+    });
+});


### PR DESCRIPTION
## The problem

Two compounding issues surfaced by #308 (rate-limited cards):

1. **The token pool only added failover, not throughput.** Rotation always started at index 0, so `GITHUB_TOKEN`'s account burned its entire hourly GraphQL quota while `GITHUB_TOKEN_1` idled. The pool's combined capacity was never actually usable — the second account only saw traffic after the first was already dead.
2. **Error logs and a source comment leaked the backing account.** GitHub's exhaustion message names the account behind the token ("API rate limit already exceeded for user ID …"), and it flowed raw into console logs, Sentry, Axiom, and GA. One source comment even quoted the real account id in this public repo.

## The change

**Spread:** each username is pinned to a deterministic starting token (djb2 hash of the lowercased login, mod pool size). Rotation walks one full lap around the pool and then fails with the canonical "No more GITHUB_TOKEN" error (which `classifyError` already maps to the rate-limited card). With N accounts in the pool this makes time-to-exhaustion scale with N instead of always draining account 0 first.

**Redaction:** `redactBackingAccount()` scrubs "user ID <n>" from error messages in place before they reach any sink. Rotation logs now name the token slot (`GITHUB_TOKEN_1 failed: …`) — which is what operations needs — instead of the account identity. The source comment quoting a real account id is rewritten.

`getGitHubTokenCount()` (contiguous slots from index 0, `GITHUB_TOKEN` counts as slot 0) and `getGitHubTokenName()` are new in `github-token-updater.ts`; `getGitHubToken`'s behavior is unchanged.

## Testing

- 26 suites / 209 tests green, lint + typecheck clean.
- New: token count/name resolution (production shape `GITHUB_TOKEN` + `GITHUB_TOKEN_1`, gap handling), hash determinism/range/spread, and end-to-end rotation through `handleCard` — pinned start, wrap-around rescue, exactly-one-lap exhaustion, no account id in any rendered card or shipped message.

Refs #308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub token rotation by distributing requests across configured tokens and wrapping through the pool when rate limits or authentication errors occur.
  * Added clearer handling when all available tokens are exhausted.
  * Redacted backing-account identifiers from displayed and logged error messages.
  * Improved token configuration detection and fallback behavior for the primary token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->