### PR TITLE
fix: fetch star totals via stargazerCount, not the stargazers connection

### DIFF
--- a/src/github-api/organization-details.ts
+++ b/src/github-api/organization-details.ts
@@ -61,9 +61,7 @@ const fetcher = (token: string, variables: any) => {
                     nodes {
                         createdAt
                         forkCount
-                        stargazers {
-                            totalCount
-                        }
+                        stargazerCount
                         issues(states: OPEN) {
                             totalCount
                         }
@@ -144,7 +142,7 @@ export async function getOrganizationDetails(login: string, token: string): Prom
     organizationDetails.totalPublicRepos = org.totalPublicRepos;
 
     for (const node of nodes) {
-        organizationDetails.totalStars += node.stargazers.totalCount;
+        organizationDetails.totalStars += node.stargazerCount;
         organizationDetails.totalForks += node.forkCount;
         organizationDetails.totalOpenIssues += node.issues.totalCount;
         organizationDetails.repoCreatedAt.push(new Date(node.createdAt));

--- a/src/github-api/profile-details.ts
+++ b/src/github-api/profile-details.ts
@@ -57,9 +57,7 @@ const fetcher = (token: string, variables: any) => {
             repositories(first: 100,privacy:PUBLIC, isFork: false, ownerAffiliations: OWNER) {
               totalCount
               nodes {
-                stargazers {
-                  totalCount
-                }
+                stargazerCount
               }
               pageInfo {
                 endCursor
@@ -122,9 +120,7 @@ const coreFetcher = (token: string, variables: any) => {
             repositories(first: 100,privacy:PUBLIC, isFork: false, ownerAffiliations: OWNER) {
               totalCount
               nodes {
-                stargazers {
-                  totalCount
-                }
+                stargazerCount
               }
               pageInfo {
                 endCursor
@@ -311,9 +307,7 @@ const starsFetcher = (token: string, variables: any) => {
         user(login: $login) {
             repositories(first: 100, after: $endCursor, privacy:PUBLIC, isFork: false, ownerAffiliations: OWNER) {
               nodes {
-                stargazers {
-                  totalCount
-                }
+                stargazerCount
               }
               pageInfo {
                 endCursor
@@ -423,7 +417,7 @@ function splitFlagKey(username: string): string {
 // the profile fetch's start, not the pagination's, so the phases can't stack.
 async function paginateStars(firstPage: any, username: string, token: string, startedAt: number): Promise<number> {
     let stars: number = firstPage.nodes.reduce(
-        (acc: number, curr: {stargazers: {totalCount: number}}) => acc + curr.stargazers.totalCount,
+        (acc: number, curr: {stargazerCount: number}) => acc + curr.stargazerCount,
         0
     );
     let starsCursor: string | null = firstPage.pageInfo?.endCursor ?? null;
@@ -439,10 +433,7 @@ async function paginateStars(firstPage: any, username: string, token: string, st
         const starsRes: any = await starsFetcher(token, {login: username, endCursor: starsCursor});
         assertNoGraphQLErrors(starsRes, 'GetProfileDetails failed');
         const repos = starsRes.data.data.user.repositories;
-        stars += repos.nodes.reduce(
-            (acc: number, curr: {stargazers: {totalCount: number}}) => acc + curr.stargazers.totalCount,
-            0
-        );
+        stars += repos.nodes.reduce((acc: number, curr: {stargazerCount: number}) => acc + curr.stargazerCount, 0);
         starsCursor = repos.pageInfo?.endCursor ?? null;
         starsPages += 1;
         starsHasNextPage = shouldFetchNextPage(

--- a/tests/github-api/organization-details.test.ts
+++ b/tests/github-api/organization-details.test.ts
@@ -23,19 +23,19 @@ const firstPage = {
                     {
                         createdAt: '2020-01-01T00:00:00Z',
                         forkCount: 5,
-                        stargazers: {totalCount: 100},
+                        stargazerCount: 100,
                         issues: {totalCount: 3}
                     },
                     {
                         createdAt: '2021-03-15T00:00:00Z',
                         forkCount: 2,
-                        stargazers: {totalCount: 50},
+                        stargazerCount: 50,
                         issues: {totalCount: 1}
                     },
                     {
                         createdAt: '2022-06-30T00:00:00Z',
                         forkCount: 1,
-                        stargazers: {totalCount: 25},
+                        stargazerCount: 25,
                         issues: {totalCount: 0}
                     }
                 ]

--- a/tests/github-api/profile-details.test.ts
+++ b/tests/github-api/profile-details.test.ts
@@ -16,7 +16,7 @@ const data = {
             websiteUrl: null,
             repositories: {
                 totalCount: 30,
-                nodes: [{stargazers: {totalCount: 110}}, {stargazers: {totalCount: 20}}]
+                nodes: [{stargazerCount: 110}, {stargazerCount: 20}]
             },
             issues: {totalCount: 10},
             repositoriesContributedTo: {totalCount: 30},
@@ -342,7 +342,7 @@ describe('github api for profile details', () => {
             data: {
                 user: {
                     repositories: {
-                        nodes: [{stargazers: {totalCount: 7}}, {stargazers: {totalCount: 3}}],
+                        nodes: [{stargazerCount: 7}, {stargazerCount: 3}],
                         pageInfo: {endCursor: null, hasNextPage: false}
                     }
                 }


### PR DESCRIPTION
## The problem

Between July 22 and 23, GitHub's GraphQL API stopped serving the `stargazers` connection to integration tokens (the built-in Actions `GITHUB_TOKEN`), answering `Resource not accessible by integration` — with the rest of the document intact. Since `assertNoGraphQLErrors` treats any errors array as fatal, exactly the two cards whose queries touch that field — ProfileDetailsCard and StatsCard — fail outright for every Action user on the default token setup (#311). PAT-backed runs and the hosted service are unaffected.

Nothing changed on our side: the reporter's runs on the 22nd and 23rd resolved the same action build (`89776cd`), clean one day and failing the next. Verified against their public run logs (0 errors on 7/22, 2 on 7/23 and 7/24), and reproduced in a scratch repo with a fresh Actions token: the full `UserDetails` document errors at `["user","repositories","nodes",0,"stargazers"]` while every other field succeeds. Not in GitHub's GraphQL changelog — either an unannounced tightening or a regression on their end.

## The change

The queries only ever read `stargazers { totalCount }`. `Repository.stargazerCount` returns the same number, costs less, and is verified working with integration tokens (probed user + organization shapes with an Actions token). Swapped in across:

- `profile-details.ts` — combined `UserDetails`, split `UserDetailsCore`, and the `UserStars` pagination document, plus both star-sum reducers
- `organization-details.ts` — the org repositories query and its star-sum loop

No card output changes; the number is identical. This also unblocks the planned move of the hosted service onto a GitHub App installation token, which would have hit the same restriction.

## Testing

26 suites / 223 tests green (fixtures updated to the new field shape), typecheck + lint clean.

Fixes #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository star-count retrieval for profile and organization details.
  * Ensured star totals remain accurate across paginated repository results.

* **Tests**
  * Updated coverage to validate the revised repository star-count responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->