### PR TITLE
feat(api): GitHub App installation tokens join the token pool

### DIFF
--- a/api/utils/github-app-token.ts
+++ b/api/utils/github-app-token.ts
@@ -17,6 +17,10 @@ import axios from 'axios';
 // per hour. They are never logged and never written to Redis.
 
 const REFRESH_MARGIN_MS = 5 * 60 * 1000; // re-mint when under 5 minutes left
+// A hanging mint would otherwise ride the whole function invocation while the
+// rotation can't move on — bound it so a slow GitHub API degrades to the PAT
+// slots within a request, not at the platform timeout.
+const MINT_TIMEOUT_MS = 10 * 1000;
 
 const cachedTokens = new Map<number, {token: string; expiresAtMs: number}>();
 const inflightMints = new Map<number, Promise<string>>();
@@ -76,7 +80,8 @@ async function appApi(method: 'get' | 'post', path: string, jwt: string): Promis
             'User-Agent': 'github-profile-summary-cards',
             Authorization: `Bearer ${jwt}`,
             Accept: 'application/vnd.github+json'
-        }
+        },
+        timeout: MINT_TIMEOUT_MS
     });
 }
 

--- a/api/utils/github-app-token.ts
+++ b/api/utils/github-app-token.ts
@@ -1,0 +1,150 @@
+import * as crypto from 'crypto';
+import axios from 'axios';
+
+// GitHub App installation tokens: minted on demand from the App's private key,
+// valid for one hour, with their own 5,000-point GraphQL quota per
+// INSTALLATION — install the same App on several accounts and each
+// installation is an independent quota pool, all from one credential.
+//
+// Configuration (Vercel env):
+//   GH_APP_ID               — the App's numeric id
+//   GH_APP_PRIVATE_KEY      — PEM, either verbatim (multiline / \n-escaped) or base64
+//   GH_APP_INSTALLATION_IDS — optional, comma-separated; one token slot per id.
+//                             Omitted: the first discovered installation is used.
+//
+// Minted tokens are cached in module memory per lambda instance and refreshed
+// shortly before expiry — roughly two REST calls per installation per instance
+// per hour. They are never logged and never written to Redis.
+
+const REFRESH_MARGIN_MS = 5 * 60 * 1000; // re-mint when under 5 minutes left
+
+const cachedTokens = new Map<number, {token: string; expiresAtMs: number}>();
+const inflightMints = new Map<number, Promise<string>>();
+let discoveredInstallationId: number | null = null;
+
+export function isGitHubAppConfigured(): boolean {
+    return Boolean(process.env.GH_APP_ID && process.env.GH_APP_PRIVATE_KEY);
+}
+
+function configuredInstallationIds(): number[] {
+    return (process.env.GH_APP_INSTALLATION_IDS ?? '')
+        .split(',')
+        .map(s => Number(s.trim()))
+        .filter(n => Number.isInteger(n) && n > 0);
+}
+
+// Slot count must be known synchronously for the rotation pool, so it comes
+// from env only: one slot per configured installation id, or a single slot
+// (first discovered installation) when none are pinned.
+export function getGitHubAppSlotCount(): number {
+    if (!isGitHubAppConfigured()) {
+        return 0;
+    }
+    return Math.max(1, configuredInstallationIds().length);
+}
+
+// Vercel env vars arrive in several shapes: verbatim PEM, PEM with literal \n
+// escapes, or base64 of the whole file. Normalize all three.
+function resolvePrivateKey(): string {
+    let key = process.env.GH_APP_PRIVATE_KEY ?? '';
+    if (!key.includes('-----BEGIN')) {
+        key = Buffer.from(key, 'base64').toString('utf8');
+    }
+    return key.replace(/\\n/g, '\n');
+}
+
+// A short-lived RS256 JWT identifying the App itself (not an installation).
+// Node's crypto signs it directly — no jsonwebtoken dependency.
+function buildAppJwt(): string {
+    const now = Math.floor(Date.now() / 1000);
+    const encode = (obj: object): string => Buffer.from(JSON.stringify(obj)).toString('base64url');
+    // iat backdated 60s against clock drift; GitHub caps exp at 10 minutes.
+    const unsigned = `${encode({alg: 'RS256', typ: 'JWT'})}.${encode({
+        iat: now - 60,
+        exp: now + 540,
+        iss: process.env.GH_APP_ID
+    })}`;
+    const signature = crypto.createSign('RSA-SHA256').update(unsigned).sign(resolvePrivateKey(), 'base64url');
+    return `${unsigned}.${signature}`;
+}
+
+async function appApi(method: 'get' | 'post', path: string, jwt: string): Promise<any> {
+    return axios({
+        url: `https://api.github.com${path}`,
+        method,
+        headers: {
+            'User-Agent': 'github-profile-summary-cards',
+            Authorization: `Bearer ${jwt}`,
+            Accept: 'application/vnd.github+json'
+        }
+    });
+}
+
+async function resolveInstallationId(slot: number, jwt: string): Promise<number> {
+    const pinned = configuredInstallationIds();
+    if (pinned.length > 0) {
+        return pinned[slot];
+    }
+    if (discoveredInstallationId !== null) {
+        return discoveredInstallationId;
+    }
+    const res = await appApi('get', '/app/installations', jwt);
+    const id = res.data?.[0]?.id;
+    if (!id) {
+        throw new Error('GitHub App has no installations');
+    }
+    discoveredInstallationId = id;
+    return id;
+}
+
+async function mintInstallationToken(slot: number): Promise<string> {
+    const jwt = buildAppJwt();
+    const installationId = await resolveInstallationId(slot, jwt);
+    const res = await appApi('post', `/app/installations/${installationId}/access_tokens`, jwt);
+    const token = res.data?.token;
+    if (!token) {
+        throw new Error('GitHub App token mint returned no token');
+    }
+    cachedTokens.set(slot, {
+        token,
+        expiresAtMs: res.data.expires_at ? Date.parse(res.data.expires_at) : Date.now() + 55 * 60 * 1000
+    });
+    return token;
+}
+
+/**
+ * Returns a valid installation token for an App slot, minting or refreshing as
+ * needed. Concurrent callers of the same slot share one in-flight mint. Throws
+ * when the App is not configured or GitHub rejects the mint — callers treat
+ * that as "this slot can't serve the request" and rotate on.
+ *
+ * @param {number} slot - App slot index, 0 <= slot < getGitHubAppSlotCount().
+ * @return {Promise<string>} The installation access token.
+ */
+export async function getGitHubAppToken(slot = 0): Promise<string> {
+    if (!isGitHubAppConfigured()) {
+        throw new Error('GitHub App is not configured');
+    }
+    if (slot < 0 || slot >= getGitHubAppSlotCount()) {
+        throw new Error(`GitHub App slot out of range: ${slot}`);
+    }
+    const cached = cachedTokens.get(slot);
+    if (cached && cached.expiresAtMs - Date.now() > REFRESH_MARGIN_MS) {
+        return cached.token;
+    }
+    let mint = inflightMints.get(slot);
+    if (!mint) {
+        mint = mintInstallationToken(slot).finally(() => {
+            inflightMints.delete(slot);
+        });
+        inflightMints.set(slot, mint);
+    }
+    return mint;
+}
+
+/** Test hook: clears module-level caches between test cases. */
+export function __resetGitHubAppTokenCacheForTests(): void {
+    cachedTokens.clear();
+    inflightMints.clear();
+    discoveredInstallationId = null;
+}

--- a/api/utils/github-token-updater.ts
+++ b/api/utils/github-token-updater.ts
@@ -1,3 +1,5 @@
+import {getGitHubAppSlotCount, getGitHubAppToken} from './github-app-token';
+
 // Returns the env var name a given token index resolves from: GITHUB_TOKEN_<n>
 // when set, with GITHUB_TOKEN as the index-0 fallback. Safe to log — it names
 // the slot, never the token value or the account behind it.
@@ -37,4 +39,43 @@ export const getGitHubTokenCount = function (): number {
         count += 1;
     }
     return count;
+};
+
+// ---- unified slot view: GitHub App installations + env PATs ----
+// App installations come first (each installation token has its own hourly
+// quota, independent of every PAT account and of each other); the env PATs
+// follow, shifted by the App slot count. Without an App the slots are exactly
+// the env PATs.
+export const getGitHubTokenSlots = function (): number {
+    return getGitHubAppSlotCount() + getGitHubTokenCount();
+};
+
+// Loggable slot name — 'GITHUB_APP[_n]' for App slots, env var names otherwise.
+export const getGitHubTokenNameAt = function (index: number): string {
+    const appSlots = getGitHubAppSlotCount();
+    if (index < appSlots) {
+        return appSlots === 1 ? 'GITHUB_APP' : `GITHUB_APP_${index}`;
+    }
+    return getGitHubTokenName(index - appSlots);
+};
+
+// Resolves the token at a slot. App slots mint (or serve the cached)
+// installation token; mint failures are flagged `isTokenAcquisition` so the
+// rotation treats a broken App like a rate-limited PAT — try the next slot
+// instead of failing the card.
+export const getGitHubTokenAt = async function (index: number): Promise<string> {
+    const appSlots = getGitHubAppSlotCount();
+    if (index < appSlots) {
+        try {
+            const token = await getGitHubAppToken(index);
+            console.log(`Using token source: ${getGitHubTokenNameAt(index)}`);
+            return token;
+        } catch (err: any) {
+            if (err && typeof err === 'object') {
+                err.isTokenAcquisition = true;
+            }
+            throw err;
+        }
+    }
+    return getGitHubToken(index - appSlots);
 };

--- a/api/utils/handle-card.ts
+++ b/api/utils/handle-card.ts
@@ -1,4 +1,4 @@
-import {getGitHubToken, getGitHubTokenCount, getGitHubTokenName} from './github-token-updater';
+import {getGitHubTokenAt, getGitHubTokenSlots, getGitHubTokenNameAt} from './github-token-updater';
 import {getErrorMsgCard} from './error-card';
 import {reportUnexpectedError, shipErrorRecord} from './error-reporter';
 import {waitUntil} from '@vercel/functions';
@@ -110,17 +110,20 @@ export async function handleCard(
 
     try {
         await runWithRequestClock(async () => {
-            // Zero configured tokens keeps the old behavior: the first
-            // getGitHubToken(0) call throws the canonical "No more GITHUB_TOKEN"
-            // error before any render is attempted.
-            const tokenCount = Math.max(1, getGitHubTokenCount());
+            // Slots = GitHub App installation token (when configured) + env
+            // PATs. Zero configured slots keeps the old behavior: the first
+            // getGitHubTokenAt(0) call throws the canonical "No more
+            // GITHUB_TOKEN" error before any render is attempted.
+            const tokenCount = Math.max(1, getGitHubTokenSlots());
             let attempts = 0;
             let tokenIndex = tokenPoolStartIndex(username, tokenCount);
-            let token = getGitHubToken(tokenIndex);
-            // Rotate through the configured tokens (wrapping around the pool)
-            // until one succeeds or every token has been tried.
+            // Rotate through the configured slots (wrapping around the pool)
+            // until one succeeds or every slot has been tried. Acquisition
+            // happens inside the try: a failed App-token mint rotates to the
+            // next slot exactly like a rate-limited PAT.
             while (true) {
                 try {
+                    const token = await getGitHubTokenAt(tokenIndex);
                     // Collect the data-cache outcome of this render so GA gets a
                     // cache_status dimension (fresh / miss / stale / mixed).
                     const {result: cardSVG, cacheStatus} = await runWithCacheStats(() =>
@@ -151,9 +154,9 @@ export async function handleCard(
                     return;
                 } catch (err: any) {
                     console.log(
-                        `${getGitHubTokenName(tokenIndex)} failed: ${redactBackingAccount(String(err?.message ?? 'unknown'))}`
+                        `${getGitHubTokenNameAt(tokenIndex)} failed: ${redactBackingAccount(String(err?.message ?? 'unknown'))}`
                     );
-                    if (isRotatableError(err)) {
+                    if (isRotatableError(err) || err?.isTokenAcquisition === true) {
                         attempts += 1;
                         if (attempts >= tokenCount) {
                             // Keep the "No more GITHUB_TOKEN" phrasing — classifyError
@@ -161,7 +164,6 @@ export async function handleCard(
                             throw new Error('No more GITHUB_TOKEN can be used (all configured tokens failed)');
                         }
                         tokenIndex = (tokenIndex + 1) % tokenCount;
-                        token = getGitHubToken(tokenIndex);
                     } else {
                         throw err;
                     }

--- a/tests/utils/github-app-token.test.ts
+++ b/tests/utils/github-app-token.test.ts
@@ -1,0 +1,168 @@
+import * as crypto from 'crypto';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import {
+    isGitHubAppConfigured,
+    getGitHubAppSlotCount,
+    getGitHubAppToken,
+    __resetGitHubAppTokenCacheForTests
+} from '../../api/utils/github-app-token';
+
+const mock = new MockAdapter(axios);
+
+// A real (throwaway) keypair so the RS256 signature can be verified for real.
+const {publicKey, privateKey} = crypto.generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: {type: 'spki', format: 'pem'},
+    privateKeyEncoding: {type: 'pkcs8', format: 'pem'}
+});
+
+const originalEnv = {...process.env};
+
+function configureApp(extra: Record<string, string> = {}): void {
+    process.env.GH_APP_ID = '12345';
+    process.env.GH_APP_PRIVATE_KEY = privateKey;
+    delete process.env.GH_APP_INSTALLATION_IDS;
+    Object.assign(process.env, extra);
+}
+
+function decodeJwt(authHeader: string): {header: any; payload: any; verified: boolean} {
+    const jwt = authHeader.replace(/^Bearer /, '');
+    const [h, p, s] = jwt.split('.');
+    const verified = crypto
+        .createVerify('RSA-SHA256')
+        .update(`${h}.${p}`)
+        .verify(publicKey, Buffer.from(s, 'base64url'));
+    return {
+        header: JSON.parse(Buffer.from(h, 'base64url').toString()),
+        payload: JSON.parse(Buffer.from(p, 'base64url').toString()),
+        verified
+    };
+}
+
+afterEach(() => {
+    mock.reset();
+    process.env = {...originalEnv};
+    __resetGitHubAppTokenCacheForTests();
+});
+
+describe('isGitHubAppConfigured / slot count', () => {
+    it('is off without env config', () => {
+        delete process.env.GH_APP_ID;
+        delete process.env.GH_APP_PRIVATE_KEY;
+        expect(isGitHubAppConfigured()).toBe(false);
+        expect(getGitHubAppSlotCount()).toBe(0);
+    });
+
+    it('is one slot when configured without pinned installations', () => {
+        configureApp();
+        expect(isGitHubAppConfigured()).toBe(true);
+        expect(getGitHubAppSlotCount()).toBe(1);
+    });
+
+    it('is one slot per pinned installation id', () => {
+        configureApp({GH_APP_INSTALLATION_IDS: '111, 222'});
+        expect(getGitHubAppSlotCount()).toBe(2);
+    });
+
+    it('ignores malformed installation ids', () => {
+        configureApp({GH_APP_INSTALLATION_IDS: 'abc, -1, 333'});
+        expect(getGitHubAppSlotCount()).toBe(1);
+    });
+});
+
+describe('getGitHubAppToken', () => {
+    it('mints via a verifiable RS256 app JWT and discovers the installation', async () => {
+        configureApp();
+        let mintAuth = '';
+        mock.onGet('https://api.github.com/app/installations').reply(200, [{id: 777}]);
+        mock.onPost('https://api.github.com/app/installations/777/access_tokens').reply(config => {
+            mintAuth = String(config.headers?.Authorization);
+            return [201, {token: 'ghs_app_token', expires_at: new Date(Date.now() + 3600_000).toISOString()}];
+        });
+
+        await expect(getGitHubAppToken()).resolves.toBe('ghs_app_token');
+        const {header, payload, verified} = decodeJwt(mintAuth);
+        expect(verified).toBe(true);
+        expect(header.alg).toBe('RS256');
+        expect(payload.iss).toBe('12345');
+        expect(payload.exp - payload.iat).toBeLessThanOrEqual(600);
+    });
+
+    it('serves the cached token without re-minting until near expiry', async () => {
+        configureApp({GH_APP_INSTALLATION_IDS: '777'});
+        let mints = 0;
+        mock.onPost('https://api.github.com/app/installations/777/access_tokens').reply(() => {
+            mints += 1;
+            return [201, {token: 'ghs_cached', expires_at: new Date(Date.now() + 3600_000).toISOString()}];
+        });
+
+        await getGitHubAppToken();
+        await getGitHubAppToken();
+        expect(mints).toBe(1);
+    });
+
+    it('re-mints when the cached token is inside the refresh margin', async () => {
+        configureApp({GH_APP_INSTALLATION_IDS: '777'});
+        let mints = 0;
+        mock.onPost('https://api.github.com/app/installations/777/access_tokens').reply(() => {
+            mints += 1;
+            // expires within the 5-minute margin, so the next call re-mints
+            return [201, {token: `ghs_${mints}`, expires_at: new Date(Date.now() + 60_000).toISOString()}];
+        });
+
+        await expect(getGitHubAppToken()).resolves.toBe('ghs_1');
+        await expect(getGitHubAppToken()).resolves.toBe('ghs_2');
+        expect(mints).toBe(2);
+    });
+
+    it('coalesces concurrent callers into one mint', async () => {
+        configureApp({GH_APP_INSTALLATION_IDS: '777'});
+        let mints = 0;
+        mock.onPost('https://api.github.com/app/installations/777/access_tokens').reply(() => {
+            mints += 1;
+            return [201, {token: 'ghs_once', expires_at: new Date(Date.now() + 3600_000).toISOString()}];
+        });
+
+        const [a, b, c] = await Promise.all([getGitHubAppToken(), getGitHubAppToken(), getGitHubAppToken()]);
+        expect([a, b, c]).toEqual(['ghs_once', 'ghs_once', 'ghs_once']);
+        expect(mints).toBe(1);
+    });
+
+    it('keeps per-installation tokens and quotas separate', async () => {
+        configureApp({GH_APP_INSTALLATION_IDS: '111,222'});
+        mock.onPost('https://api.github.com/app/installations/111/access_tokens').reply(201, {
+            token: 'ghs_first',
+            expires_at: new Date(Date.now() + 3600_000).toISOString()
+        });
+        mock.onPost('https://api.github.com/app/installations/222/access_tokens').reply(201, {
+            token: 'ghs_second',
+            expires_at: new Date(Date.now() + 3600_000).toISOString()
+        });
+
+        await expect(getGitHubAppToken(0)).resolves.toBe('ghs_first');
+        await expect(getGitHubAppToken(1)).resolves.toBe('ghs_second');
+    });
+
+    it('accepts a base64-encoded private key', async () => {
+        configureApp({GH_APP_INSTALLATION_IDS: '777'});
+        process.env.GH_APP_PRIVATE_KEY = Buffer.from(privateKey).toString('base64');
+        mock.onPost('https://api.github.com/app/installations/777/access_tokens').reply(201, {
+            token: 'ghs_b64',
+            expires_at: new Date(Date.now() + 3600_000).toISOString()
+        });
+        await expect(getGitHubAppToken()).resolves.toBe('ghs_b64');
+    });
+
+    it('throws when unconfigured, out of range, or uninstalled', async () => {
+        delete process.env.GH_APP_ID;
+        await expect(getGitHubAppToken()).rejects.toThrow('not configured');
+
+        configureApp({GH_APP_INSTALLATION_IDS: '777'});
+        await expect(getGitHubAppToken(5)).rejects.toThrow('out of range');
+
+        delete process.env.GH_APP_INSTALLATION_IDS;
+        mock.onGet('https://api.github.com/app/installations').reply(200, []);
+        await expect(getGitHubAppToken()).rejects.toThrow('no installations');
+    });
+});

--- a/tests/utils/github-token-updater.test.ts
+++ b/tests/utils/github-token-updater.test.ts
@@ -1,4 +1,11 @@
-import {getGitHubToken, getGitHubTokenCount, getGitHubTokenName} from '../../api/utils/github-token-updater';
+import {
+    getGitHubToken,
+    getGitHubTokenCount,
+    getGitHubTokenName,
+    getGitHubTokenSlots,
+    getGitHubTokenNameAt,
+    getGitHubTokenAt
+} from '../../api/utils/github-token-updater';
 
 describe('getGitHubToken', () => {
     const original = {...process.env};
@@ -82,5 +89,52 @@ describe('getGitHubTokenName', () => {
     it('names the slot even when unset (for error logs)', () => {
         delete process.env.GITHUB_TOKEN_3;
         expect(getGitHubTokenName(3)).toBe('GITHUB_TOKEN_3');
+    });
+});
+
+describe('unified slots (App + env PATs)', () => {
+    const original = {...process.env};
+    beforeEach(() => {
+        delete process.env.GH_APP_ID;
+        delete process.env.GH_APP_PRIVATE_KEY;
+        delete process.env.GH_APP_INSTALLATION_IDS;
+        process.env.GITHUB_TOKEN = 'tok0';
+        process.env.GITHUB_TOKEN_1 = 'tok1';
+        delete process.env.GITHUB_TOKEN_2;
+    });
+    afterEach(() => {
+        process.env = {...original};
+    });
+
+    it('equals the env PATs when no App is configured', () => {
+        expect(getGitHubTokenSlots()).toBe(2);
+        expect(getGitHubTokenNameAt(0)).toBe('GITHUB_TOKEN');
+        expect(getGitHubTokenNameAt(1)).toBe('GITHUB_TOKEN_1');
+    });
+
+    it('prepends App slots and shifts the PAT names', () => {
+        process.env.GH_APP_ID = '1';
+        process.env.GH_APP_PRIVATE_KEY = 'pem';
+        expect(getGitHubTokenSlots()).toBe(3);
+        expect(getGitHubTokenNameAt(0)).toBe('GITHUB_APP');
+        expect(getGitHubTokenNameAt(1)).toBe('GITHUB_TOKEN');
+        expect(getGitHubTokenNameAt(2)).toBe('GITHUB_TOKEN_1');
+    });
+
+    it('numbers App slots when several installations are pinned', () => {
+        process.env.GH_APP_ID = '1';
+        process.env.GH_APP_PRIVATE_KEY = 'pem';
+        process.env.GH_APP_INSTALLATION_IDS = '111,222';
+        expect(getGitHubTokenSlots()).toBe(4);
+        expect(getGitHubTokenNameAt(0)).toBe('GITHUB_APP_0');
+        expect(getGitHubTokenNameAt(1)).toBe('GITHUB_APP_1');
+        expect(getGitHubTokenNameAt(2)).toBe('GITHUB_TOKEN');
+    });
+
+    it('resolves PAT slots behind the App shift', async () => {
+        process.env.GH_APP_ID = '1';
+        process.env.GH_APP_PRIVATE_KEY = 'pem';
+        await expect(getGitHubTokenAt(1)).resolves.toBe('tok0');
+        await expect(getGitHubTokenAt(2)).resolves.toBe('tok1');
     });
 });

--- a/tests/utils/handle-card.test.ts
+++ b/tests/utils/handle-card.test.ts
@@ -143,7 +143,9 @@ describe('handleCard token rotation', () => {
 // The App slot participates in the same rotation: a working App serves cards,
 // a broken App (mint failure) rotates to the PATs instead of failing the card.
 describe('handleCard with a GitHub App slot', () => {
-    const mock = new MockAdapter(axios);
+    // Created per test: restore() detaches the adapter from axios, so a
+    // suite-level instance would leave later tests running unmocked.
+    let mock: InstanceType<typeof MockAdapter>;
     const originalEnv = {...process.env};
 
     // Pool: [GITHUB_APP, GITHUB_TOKEN, GITHUB_TOKEN_1]. Pick a username whose
@@ -154,7 +156,7 @@ describe('handleCard with a GitHub App slot', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-        mock.reset();
+        mock = new MockAdapter(axios);
         __resetGitHubAppTokenCacheForTests();
         process.env.GITHUB_TOKEN = 'tok0';
         process.env.GITHUB_TOKEN_1 = 'tok1';

--- a/tests/utils/handle-card.test.ts
+++ b/tests/utils/handle-card.test.ts
@@ -1,4 +1,7 @@
 import {handleCard, redactBackingAccount, tokenPoolStartIndex} from '../../api/utils/handle-card';
+import {__resetGitHubAppTokenCacheForTests} from '../../api/utils/github-app-token';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
 import type {VercelRequest, VercelResponse} from '@vercel/node';
 
 jest.mock('../../src/utils/analytics', () => ({
@@ -134,5 +137,76 @@ describe('handleCard token rotation', () => {
         expect(res.body).not.toContain('98765');
         // The in-place redaction cleans the message before it reaches any sink.
         expect(err.message).toBe('boom for the backing account');
+    });
+});
+
+// The App slot participates in the same rotation: a working App serves cards,
+// a broken App (mint failure) rotates to the PATs instead of failing the card.
+describe('handleCard with a GitHub App slot', () => {
+    const mock = new MockAdapter(axios);
+    const originalEnv = {...process.env};
+
+    // Pool: [GITHUB_APP, GITHUB_TOKEN, GITHUB_TOKEN_1]. Pick a username whose
+    // hash pins it to the App slot so the App path is exercised first.
+    const appPinnedUser = ['alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot', 'golf', 'hotel'].find(
+        name => tokenPoolStartIndex(name, 3) === 0
+    ) as string;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mock.reset();
+        __resetGitHubAppTokenCacheForTests();
+        process.env.GITHUB_TOKEN = 'tok0';
+        process.env.GITHUB_TOKEN_1 = 'tok1';
+        process.env.GH_APP_ID = '12345';
+        process.env.GH_APP_PRIVATE_KEY = 'not-a-real-key';
+        process.env.GH_APP_INSTALLATION_IDS = '777';
+    });
+
+    afterEach(() => {
+        process.env = {...originalEnv};
+        mock.restore();
+    });
+
+    const makeReq = (username: string) => ({query: {username}, headers: {}}) as any;
+    const makeRes = () => {
+        const res: any = {
+            body: undefined,
+            setHeader() {},
+            send(body: unknown) {
+                this.body = body;
+            },
+            status: jest.fn().mockReturnThis()
+        };
+        return res;
+    };
+
+    it('sanity: a username is pinned to the App slot', () => {
+        expect(appPinnedUser).toBeDefined();
+    });
+
+    it('rotates to the PATs when the App token mint fails', async () => {
+        // The bogus private key makes the mint throw before any HTTP happens —
+        // an isTokenAcquisition failure, which must rotate, not fail the card.
+        const render = jest.fn().mockResolvedValue('<svg/>');
+        const res = makeRes();
+        await handleCard(makeReq(appPinnedUser), res, 'test_card', render);
+
+        expect(render).toHaveBeenCalledTimes(1);
+        expect(['tok0', 'tok1']).toContain(render.mock.calls[0][3]);
+        expect(res.body).toContain('<svg');
+    });
+
+    it('counts the App slot in the exhaustion lap', async () => {
+        const err: any = new Error('API rate limit exceeded');
+        err.isRateLimit = true;
+        const render = jest.fn().mockRejectedValue(err);
+        const res = makeRes();
+        await handleCard(makeReq(appPinnedUser), res, 'test_card', render);
+
+        // App mint fails (1 acquisition attempt, no render) + 2 PAT renders
+        // rate-limited = one full lap of 3 slots, then the rate-limited card.
+        expect(render).toHaveBeenCalledTimes(2);
+        expect(res.body).toContain('rate limited');
     });
 });


### PR DESCRIPTION
## What

App installation tokens become first-class token-pool slots, ahead of the env PATs. This lets the hosted service run on App quota so the personal PAT can retire from the pool (#308 follow-up).

- **`api/utils/github-app-token.ts`** mints installation tokens from `GH_APP_ID` + `GH_APP_PRIVATE_KEY` (PEM verbatim, `\n`-escaped, or base64) with a hand-rolled RS256 JWT via Node `crypto` — no new dependency. Tokens cache in module memory per instance, refresh 5 minutes before expiry, and concurrent callers share one in-flight mint (~2 REST calls per installation per instance per hour). Never logged, never written to Redis.
- **One slot per installation**: `GH_APP_INSTALLATION_IDS` (comma-separated) pins them. Each installation carries its own independent 5,000-point hourly GraphQL quota — installing the App on both backing accounts yields two pools from a single credential. Unset, the first discovered installation is used.
- **Rotation-safe**: token acquisition moved inside the retry loop; a failed mint is flagged `isTokenAcquisition` and rotates to the next slot exactly like a rate-limited PAT. A broken App degrades to PAT service, not to error cards. Username-hash spread now covers `appSlots + patSlots`.
- Slot names in logs: `GITHUB_APP` / `GITHUB_APP_<n>` / `GITHUB_TOKEN_<n>` — never the accounts behind them.

## Compatibility note

The queries are already integration-token-clean: #313 replaced the `stargazers` connection (blocked for App/Actions tokens by GitHub's July change) with `stargazerCount`, and the repro verified the full profile document works with an integration token. New query fields should be probed with an Actions token before shipping.

## Rollout

1. Create the GitHub App (Settings → Developer settings → GitHub Apps): no permissions beyond the default read-only metadata, webhook off.
2. Install it on both backing accounts; note the two installation ids (from the installation page URL).
3. Vercel env: `GH_APP_ID`, `GH_APP_PRIVATE_KEY` (mark sensitive), `GH_APP_INSTALLATION_IDS=<id1>,<id2>`.
4. Deploy, watch logs for `Using token source: GITHUB_APP_0/1`.
5. Delete the personal `GITHUB_TOKEN` env; rename `GITHUB_TOKEN_1` → `GITHUB_TOKEN`. Pool becomes App×2 + machine PAT ≈ 15k points/hr, personal account fully off the hot path.

## Testing

27 suites / 241 tests green, typecheck + lint clean. New coverage: JWT signature verified against a real throwaway RSA keypair (alg, iss, exp≤10min), token caching + refresh-margin re-mint + concurrent-mint coalescing, per-installation isolation, base64/escaped PEM handling, slot arithmetic with and without the App, and handle-card rotation when the mint fails (degrades to PATs; App slot counts in the exhaustion lap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for authenticating with GitHub App installation tokens.
  - GitHub App installations are exposed as unified token “slots” alongside existing personal access token slots.
  - Tokens are cached with automatic refresh and safe reuse across concurrent requests.
- **Bug Fixes**
  - Improved card token rotation to mint per-attempt from App slots and gracefully fall back when App token acquisition fails.
  - Rate-limit/auth rotation continues across all available slots before returning an error.
- **Tests**
  - Added coverage for GitHub App token minting, caching, slot mapping, and handle-card rotation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->