### PR TITLE
perf(cache): double the default fresh window to 24h

### DIFF
--- a/src/utils/data-cache.ts
+++ b/src/utils/data-cache.ts
@@ -18,10 +18,13 @@
 
 import {AsyncLocalStorage} from 'async_hooks';
 
-// 12h: with the CDN already serving most viewers up-to-48h-old cards, a
+// 24h: with the CDN already serving most viewers up-to-48h-old cards, a
 // shorter Redis fresh window buys little visible freshness while doubling the
-// GitHub refresh traffic. Halving that traffic is a free-tier budget lever.
-const FRESH_SECONDS_DEFAULT = 12 * 60 * 60; // serve without re-fetching
+// GitHub refresh traffic. Halving that traffic is a free-tier budget lever —
+// raised from 12h on 2026-07-28 while peak hours ran close to the GitHub
+// hourly quota ceiling (#308 follow-up); card data changing at most daily is
+// indistinguishable to viewers behind the 48h CDN window anyway.
+const FRESH_SECONDS_DEFAULT = 24 * 60 * 60; // serve without re-fetching
 const RETENTION_SECONDS_DEFAULT = 7 * 24 * 60 * 60; // Redis EX — stale kept as a rate-limit fallback
 const KV_TIMEOUT_MS = 1500; // never let a slow Redis block a card render
 

--- a/tests/utils/data-cache.test.ts
+++ b/tests/utils/data-cache.test.ts
@@ -63,7 +63,7 @@ describe('withDataCache', () => {
     });
 
     it('re-fetches when the cached value is stale', async () => {
-        const staleAt = Date.now() - 13 * 60 * 60 * 1000; // older than the 12h fresh window
+        const staleAt = Date.now() - 25 * 60 * 60 * 1000; // older than the 24h fresh window
         fetchSpy
             .mockResolvedValueOnce(envelopeResponse(staleAt, 'stale'))
             .mockResolvedValueOnce({ok: true, json: async () => ({})} as Response);
@@ -72,7 +72,7 @@ describe('withDataCache', () => {
     });
 
     it('serves the stale value when the fetcher fails (rate limited)', async () => {
-        const staleAt = Date.now() - 13 * 60 * 60 * 1000;
+        const staleAt = Date.now() - 25 * 60 * 60 * 1000;
         fetchSpy.mockResolvedValueOnce(envelopeResponse(staleAt, 'stale'));
         const fetcher = jest.fn().mockRejectedValue(new Error('rate limited'));
         await expect(withDataCache('k', fetcher)).resolves.toBe('stale');
@@ -139,7 +139,7 @@ describe('runWithCacheStats', () => {
     });
 
     it('reports stale when a fallback copy was served', async () => {
-        const staleAt = Date.now() - 13 * 60 * 60 * 1000;
+        const staleAt = Date.now() - 25 * 60 * 60 * 1000;
         fetchSpy.mockResolvedValue(envelopeResponse(staleAt, 'stale'));
         const {cacheStatus} = await runWithCacheStats(async () => {
             await withDataCache('a', jest.fn().mockRejectedValue(new Error('rate limited')));


### PR DESCRIPTION
Halves steady-state GitHub refresh traffic while peak hours run close to the hourly quota ceiling (#308 follow-up). Viewers sit behind a 48h CDN window, so daily-refreshed data is indistinguishable from the previous 12h. Explicit windows (past years 90d, owner-type 7d) unchanged; stale-test fixtures aged past the new window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Cached data now remains fresh for up to 24 hours instead of 12, reducing unnecessary refreshes.
  * Stale-cache fallback behavior continues to apply when refreshed data cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->