### PR TITLE
chore: bump version to 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "github-profile-summary-cards",
-    "version": "0.11.6",
+    "version": "0.12.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "github-profile-summary-cards",
-            "version": "0.11.6",
+            "version": "0.12.0",
             "license": "MIT",
             "dependencies": {
                 "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "github-profile-summary-cards",
-    "version": "0.11.6",
+    "version": "0.12.0",
     "description": "Generate github profile summary cards",
     "main": "lib/app.js",
     "scripts": {


### PR DESCRIPTION
Version bump for the v0.12.0 release: token-pool spread + GitHub App installation tokens, REST quota offload (owner-type, repos listing, star totals), stargazerCount fix for Action users (#311), 24h fresh window, gateway-timeout narrowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.12.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->