### PR TITLE
fix: revert "chore: bump d3-color and d3" — d3 v7 is ESM-only and crashes the CJS runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+    - package-ecosystem: npm
+      directory: /
+      schedule:
+          interval: weekly
+      ignore:
+          # d3 v7+ and d3-color v3+ are ESM-only. This project compiles to
+          # CommonJS, so require('d3') crashes the Vercel runtime at module
+          # load (FUNCTION_INVOCATION_FAILED) while tests/build stay green —
+          # the #320 outage. Block major bumps until an ESM migration is done.
+          - dependency-name: d3
+            update-types: ['version-update:semver-major']
+          - dependency-name: d3-color
+            update-types: ['version-update:semver-major']

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@sentry/node": "^10.66.0",
                 "@vercel/functions": "^3.7.5",
                 "axios": "^1.18.1",
-                "d3": "^7.9.0",
+                "d3": "^6.7.0",
                 "dotenv": "^8.2.0",
                 "jest-junit": "^17.0.0",
                 "js-abbreviation-number": "^1.4.0",
@@ -5447,13 +5447,10 @@
             }
         },
         "node_modules/commander": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10"
-            }
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "license": "MIT"
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -5558,417 +5555,330 @@
             "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
         },
         "node_modules/d3": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
-            "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
-            "license": "ISC",
+            "version": "6.7.0",
+            "resolved": "https://registry.npmjs.org/d3/-/d3-6.7.0.tgz",
+            "integrity": "sha512-hNHRhe+yCDLUG6Q2LwvR/WdNFPOJQ5VWqsJcwIYVeI401+d2/rrCjxSXkiAdIlpx7/73eApFB4Olsmh3YN7a6g==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "d3-array": "3",
-                "d3-axis": "3",
-                "d3-brush": "3",
-                "d3-chord": "3",
-                "d3-color": "3",
-                "d3-contour": "4",
-                "d3-delaunay": "6",
-                "d3-dispatch": "3",
-                "d3-drag": "3",
-                "d3-dsv": "3",
-                "d3-ease": "3",
-                "d3-fetch": "3",
-                "d3-force": "3",
-                "d3-format": "3",
-                "d3-geo": "3",
-                "d3-hierarchy": "3",
-                "d3-interpolate": "3",
-                "d3-path": "3",
-                "d3-polygon": "3",
-                "d3-quadtree": "3",
-                "d3-random": "3",
-                "d3-scale": "4",
-                "d3-scale-chromatic": "3",
-                "d3-selection": "3",
-                "d3-shape": "3",
-                "d3-time": "3",
-                "d3-time-format": "4",
-                "d3-timer": "3",
-                "d3-transition": "3",
-                "d3-zoom": "3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-array": "2",
+                "d3-axis": "2",
+                "d3-brush": "2",
+                "d3-chord": "2",
+                "d3-color": "2",
+                "d3-contour": "2",
+                "d3-delaunay": "5",
+                "d3-dispatch": "2",
+                "d3-drag": "2",
+                "d3-dsv": "2",
+                "d3-ease": "2",
+                "d3-fetch": "2",
+                "d3-force": "2",
+                "d3-format": "2",
+                "d3-geo": "2",
+                "d3-hierarchy": "2",
+                "d3-interpolate": "2",
+                "d3-path": "2",
+                "d3-polygon": "2",
+                "d3-quadtree": "2",
+                "d3-random": "2",
+                "d3-scale": "3",
+                "d3-scale-chromatic": "2",
+                "d3-selection": "2",
+                "d3-shape": "2",
+                "d3-time": "2",
+                "d3-time-format": "3",
+                "d3-timer": "2",
+                "d3-transition": "2",
+                "d3-zoom": "2"
             }
         },
         "node_modules/d3-array": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-            "license": "ISC",
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+            "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "internmap": "1 - 2"
-            },
-            "engines": {
-                "node": ">=12"
+                "internmap": "^1.0.0"
             }
         },
         "node_modules/d3-axis": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
-            "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-2.1.0.tgz",
+            "integrity": "sha512-z/G2TQMyuf0X3qP+Mh+2PimoJD41VOCjViJzT0BHeL/+JQAofkiWZbWxlwFGb1N8EN+Cl/CW+MUKbVzr1689Cw==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/d3-brush": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
-            "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
-            "license": "ISC",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-2.1.0.tgz",
+            "integrity": "sha512-cHLLAFatBATyIKqZOkk/mDHUbzne2B3ZwxkzMHvFTCZCmLaXDpZRihQSn8UNXTkGD/3lb/W2sQz0etAftmHMJQ==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "d3-dispatch": "1 - 3",
-                "d3-drag": "2 - 3",
-                "d3-interpolate": "1 - 3",
-                "d3-selection": "3",
-                "d3-transition": "3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-dispatch": "1 - 2",
+                "d3-drag": "2",
+                "d3-interpolate": "1 - 2",
+                "d3-selection": "2",
+                "d3-transition": "2"
             }
         },
         "node_modules/d3-chord": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
-            "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
-            "license": "ISC",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-2.0.0.tgz",
+            "integrity": "sha512-D5PZb7EDsRNdGU4SsjQyKhja8Zgu+SHZfUSO5Ls8Wsn+jsAKUUGkcshLxMg9HDFxG3KqavGWaWkJ8EpU8ojuig==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "d3-path": "1 - 3"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/d3-color": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
+                "d3-path": "1 - 2"
             }
         },
         "node_modules/d3-contour": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
-            "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
-            "license": "ISC",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-2.0.0.tgz",
+            "integrity": "sha512-9unAtvIaNk06UwqBmvsdHX7CZ+NPDZnn8TtNH1myW93pWJkhsV25JcgnYAu0Ck5Veb1DHiCv++Ic5uvJ+h50JA==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "d3-array": "^3.2.0"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-array": "2"
             }
         },
         "node_modules/d3-delaunay": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-            "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
+            "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
             "license": "ISC",
             "dependencies": {
-                "delaunator": "5"
-            },
-            "engines": {
-                "node": ">=12"
+                "delaunator": "4"
             }
         },
         "node_modules/d3-dispatch": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
-            "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+            "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/d3-drag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
-            "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
-            "license": "ISC",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
+            "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "d3-dispatch": "1 - 3",
-                "d3-selection": "3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-dispatch": "1 - 2",
+                "d3-selection": "2"
             }
         },
         "node_modules/d3-dsv": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
-            "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
-            "license": "ISC",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
+            "integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "commander": "7",
-                "iconv-lite": "0.6",
+                "commander": "2",
+                "iconv-lite": "0.4",
                 "rw": "1"
             },
             "bin": {
-                "csv2json": "bin/dsv2json.js",
-                "csv2tsv": "bin/dsv2dsv.js",
-                "dsv2dsv": "bin/dsv2dsv.js",
-                "dsv2json": "bin/dsv2json.js",
-                "json2csv": "bin/json2dsv.js",
-                "json2dsv": "bin/json2dsv.js",
-                "json2tsv": "bin/json2dsv.js",
-                "tsv2csv": "bin/dsv2dsv.js",
-                "tsv2json": "bin/dsv2json.js"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/d3-dsv/node_modules/iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
+                "csv2json": "bin/dsv2json",
+                "csv2tsv": "bin/dsv2dsv",
+                "dsv2dsv": "bin/dsv2dsv",
+                "dsv2json": "bin/dsv2json",
+                "json2csv": "bin/json2dsv",
+                "json2dsv": "bin/json2dsv",
+                "json2tsv": "bin/json2dsv",
+                "tsv2csv": "bin/dsv2dsv",
+                "tsv2json": "bin/dsv2json"
             }
         },
         "node_modules/d3-ease": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
+            "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/d3-fetch": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
-            "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
-            "license": "ISC",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-2.0.0.tgz",
+            "integrity": "sha512-TkYv/hjXgCryBeNKiclrwqZH7Nb+GaOwo3Neg24ZVWA3MKB+Rd+BY84Nh6tmNEMcjUik1CSUWjXYndmeO6F7sw==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "d3-dsv": "1 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-dsv": "1 - 2"
             }
         },
         "node_modules/d3-force": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
-            "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
-            "license": "ISC",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.1.1.tgz",
+            "integrity": "sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "d3-dispatch": "1 - 3",
-                "d3-quadtree": "1 - 3",
-                "d3-timer": "1 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-dispatch": "1 - 2",
+                "d3-quadtree": "1 - 2",
+                "d3-timer": "1 - 2"
             }
         },
         "node_modules/d3-format": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
-            "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+            "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/d3-geo": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
-            "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
-            "license": "ISC",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+            "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "d3-array": "2.5.0 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-array": "^2.5.0"
             }
         },
         "node_modules/d3-hierarchy": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
-            "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
+            "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/d3-interpolate": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-            "license": "ISC",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+            "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "d3-color": "1 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-color": "1 - 2"
             }
+        },
+        "node_modules/d3-interpolate/node_modules/d3-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+            "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/d3-path": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+            "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/d3-polygon": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
-            "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-2.0.0.tgz",
+            "integrity": "sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/d3-quadtree": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
-            "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
+            "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/d3-random": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
-            "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-2.2.2.tgz",
+            "integrity": "sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/d3-scale": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-            "license": "ISC",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+            "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "d3-array": "2.10.0 - 3",
-                "d3-format": "1 - 3",
-                "d3-interpolate": "1.2.0 - 3",
-                "d3-time": "2.1.1 - 3",
-                "d3-time-format": "2 - 4"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-array": "^2.3.0",
+                "d3-format": "1 - 2",
+                "d3-interpolate": "1.2.0 - 2",
+                "d3-time": "^2.1.1",
+                "d3-time-format": "2 - 3"
             }
         },
         "node_modules/d3-scale-chromatic": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-            "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
-            "license": "ISC",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
+            "integrity": "sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "d3-color": "1 - 3",
-                "d3-interpolate": "1 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-color": "1 - 2",
+                "d3-interpolate": "1 - 2"
             }
+        },
+        "node_modules/d3-scale-chromatic/node_modules/d3-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+            "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/d3-selection": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-            "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
+            "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/d3-shape": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-            "license": "ISC",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
+            "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "d3-path": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-path": "1 - 2"
             }
         },
         "node_modules/d3-time": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-            "license": "ISC",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+            "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "d3-array": "2 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-array": "2"
             }
         },
         "node_modules/d3-time-format": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-            "license": "ISC",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+            "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "d3-time": "1 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-time": "1 - 2"
             }
         },
         "node_modules/d3-timer": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+            "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/d3-transition": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
-            "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
-            "license": "ISC",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
+            "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "d3-color": "1 - 3",
-                "d3-dispatch": "1 - 3",
-                "d3-ease": "1 - 3",
-                "d3-interpolate": "1 - 3",
-                "d3-timer": "1 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-color": "1 - 2",
+                "d3-dispatch": "1 - 2",
+                "d3-ease": "1 - 2",
+                "d3-interpolate": "1 - 2",
+                "d3-timer": "1 - 2"
             },
             "peerDependencies": {
-                "d3-selection": "2 - 3"
+                "d3-selection": "2"
             }
         },
+        "node_modules/d3-transition/node_modules/d3-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+            "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+            "license": "BSD-3-Clause"
+        },
         "node_modules/d3-zoom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
-            "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
-            "license": "ISC",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
+            "integrity": "sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "d3-dispatch": "1 - 3",
-                "d3-drag": "2 - 3",
-                "d3-interpolate": "1 - 3",
-                "d3-selection": "2 - 3",
-                "d3-transition": "2 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-dispatch": "1 - 2",
+                "d3-drag": "2",
+                "d3-interpolate": "1 - 2",
+                "d3-selection": "2",
+                "d3-transition": "2"
             }
+        },
+        "node_modules/d3/node_modules/d3-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+            "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/data-urls": {
             "version": "2.0.0",
@@ -6037,13 +5947,10 @@
             }
         },
         "node_modules/delaunator": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
-            "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
-            "license": "ISC",
-            "dependencies": {
-                "robust-predicates": "^3.0.2"
-            }
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+            "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==",
+            "license": "ISC"
         },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
@@ -7485,13 +7392,10 @@
             "dev": true
         },
         "node_modules/internmap": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+            "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+            "license": "ISC"
         },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
@@ -9853,12 +9757,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
-        },
-        "node_modules/robust-predicates": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
-            "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
-            "license": "Unlicense"
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "@sentry/node": "^10.66.0",
         "@vercel/functions": "^3.7.5",
         "axios": "^1.18.1",
-        "d3": "^7.9.0",
+        "d3": "^6.7.0",
         "dotenv": "^8.2.0",
         "jest-junit": "^17.0.0",
         "js-abbreviation-number": "^1.4.0",


### PR DESCRIPTION
Production went down (#320): every card endpoint returned FUNCTION_INVOCATION_FAILED. Runtime logs show the crash at module load:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module /var/task/node_modules/d3/src/index.js
from /var/task/src/templates/card.js not supported.
```

d3 v7 (and d3-color v3) are ESM-only; this project compiles to CommonJS, so `require('d3')` throws before any handler runs — the same failure mode as the July d3-color incident (#275). Local tests/tsc/ncc stay green because they resolve modules differently than Vercel's runtime loader, which is why #318 passed CI. The outage shipped inside v0.12.0 and was masked by the 48h CDN window until cached cards expired.

Production is **already restored** via a hotfix push to `release` carrying this same revert — this PR reconciles `main` so the next regular deploy doesn't re-ship the crash.

Also adds `.github/dependabot.yml` ignoring semver-major updates for d3/d3-color so this class of bump stops arriving until a proper ESM migration is planned.

Refs #320 (left open for monitoring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly maintenance checks to help keep the application’s supporting components current.
  * Updated underlying visualization support for improved compatibility and stability.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->