### PR TITLE
feat: support exclude_repos on the productive-time card

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@
   - username
   - utcOffset
   - exclude_repos:
-    - A comma separated list of repository names whose commits are excluded from the chart (case-insensitive), e.g., exclude_repos=dotfiles,my-fork
+    - A comma-separated list of repository names whose commits are excluded from the chart (case-insensitive), e.g., exclude_repos=dotfiles,my-fork
     - `owner/repo` entries also match, e.g., exclude_repos=vn7n24fzkq/dotfiles
 
 ### Custom colors

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@
   - theme
   - username
   - utcOffset
+  - exclude_repos:
+    - A comma separated list of repository names whose commits are excluded from the chart (case-insensitive), e.g., exclude_repos=dotfiles,my-fork
+    - `owner/repo` entries also match, e.g., exclude_repos=vn7n24fzkq/dotfiles
 
 ### Custom colors
 

--- a/api/cards/productive-time.ts
+++ b/api/cards/productive-time.ts
@@ -9,10 +9,17 @@ const ORG_NOT_SUPPORTED =
 
 export default (req: VercelRequest, res: VercelResponse) => {
     const {utcOffset: rawOffset = '0'} = req.query;
+    const excludeReposRaw = req.query.exclude_repos ?? '';
     if (typeof rawOffset !== 'string') {
         res.status(400).send('utcOffset must be a string');
         return;
     }
+    if (typeof excludeReposRaw !== 'string') {
+        res.status(400).send('exclude_repos must be a string');
+        return;
+    }
+    // Comma-separated repo names to skip (case-insensitive), e.g. exclude_repos=dotfiles,my-fork
+    const excludeReposArr = excludeReposRaw.split(',').map(val => val.trim().toLowerCase());
     // Validate + clamp to a real UTC offset range so a non-numeric value can't
     // produce an all-zero chart (NaN index) and a huge value can't grow the
     // 24-hour bucket array out of range (which throws in the template).
@@ -27,8 +34,8 @@ export default (req: VercelRequest, res: VercelResponse) => {
             if (ownerType === 'Organization') {
                 return getErrorMsgCard(ORG_NOT_SUPPORTED, theme);
             }
-            return getProductiveTimeSVGWithThemeName(username, theme, utcOffset, token, override);
+            return getProductiveTimeSVGWithThemeName(username, theme, utcOffset, token, override, excludeReposArr);
         },
-        {utcOffset: String(utcOffset)}
+        {utcOffset: String(utcOffset), exclude_repos_used: String(excludeReposRaw.length > 0)}
     );
 };

--- a/src/app.ts
+++ b/src/app.ts
@@ -87,7 +87,7 @@ const generateUserCards = async (
     // ProductiveTimeCard
     try {
         core.info(`Creating ProductiveTimeCard...`);
-        await createProductiveTimeCard(username, utcOffset, token, options);
+        await createProductiveTimeCard(username, utcOffset, token, options, excludeRepos);
     } catch (error: any) {
         core.error(`Error when creating ProductiveTimeCard \n${error.stack}`);
     }

--- a/src/cards/productive-time-card.ts
+++ b/src/cards/productive-time-card.ts
@@ -7,9 +7,10 @@ export const createProductiveTimeCard = async function (
     username: string,
     utcOffset: number,
     token: string,
-    options: CardGenerationOptions = {}
+    options: CardGenerationOptions = {},
+    excludeRepos: Array<string> = []
 ) {
-    const productiveTimeData = await getProductiveTimeData(username, utcOffset, token);
+    const productiveTimeData = await getProductiveTimeData(username, utcOffset, token, excludeRepos);
     // use 4- prefix for sort in preview
     writeThemedCards(
         '4-productive-time',
@@ -23,10 +24,11 @@ export const getProductiveTimeSVGWithThemeName = async function (
     themeName: string,
     utcOffset: number,
     token: string,
-    override?: ThemeColorOverride
+    override?: ThemeColorOverride,
+    excludeRepos: Array<string> = []
 ) {
     if (!ThemeMap.has(themeName)) throw new Error('Theme does not exist');
-    const productiveTimeData = await getProductiveTimeData(username, utcOffset, token);
+    const productiveTimeData = await getProductiveTimeData(username, utcOffset, token, excludeRepos);
     return getProductiveTimeSVG(productiveTimeData, themeName, utcOffset, override);
 };
 
@@ -61,7 +63,8 @@ const adjustOffset = function (offset: number, RoundRobin: {offset: number}): nu
 const getProductiveTimeData = async function (
     username: string,
     utcOffset: number,
-    token: string
+    token: string,
+    excludeRepos: Array<string> = []
 ): Promise<Array<number>> {
     // Round the 1-year window to UTC day boundaries: the values feed the
     // data-cache key, and millisecond-precision timestamps made the key unique
@@ -71,7 +74,13 @@ const getProductiveTimeData = async function (
     until.setUTCHours(24, 0, 0, 0); // end of the current UTC day
     const since = new Date(until);
     since.setUTCFullYear(since.getUTCFullYear() - 1);
-    const productiveTime = await getProductiveTime(username, until.toISOString(), since.toISOString(), token);
+    const productiveTime = await getProductiveTime(
+        username,
+        until.toISOString(),
+        since.toISOString(),
+        token,
+        excludeRepos
+    );
     // process productiveTime
     const chartData = new Array(24);
     chartData.fill(0);

--- a/src/github-api/productive-time.ts
+++ b/src/github-api/productive-time.ts
@@ -67,6 +67,7 @@ const fetcher = (token: string, variables: any) => {
                   }
                 }
                 name
+                nameWithOwner
               }
             }
           }
@@ -83,12 +84,14 @@ export async function getProductiveTime(
     username: string,
     until: string,
     since: string,
-    token: string
+    token: string,
+    excludeRepos: Array<string> = []
 ): Promise<ProfuctiveTime> {
     // The since/until window shifts with the current date, so it's part of the
     // key — plain commit-date strings are cached, Date-like usage stays outside.
-    // v3: the collection window is now pinned to since/until (repo list changed).
-    const authoredDates = await withDataCache(`v3:pt:${username.toLowerCase()}:${since}:${until}`, async () => {
+    // v4: dates are cached grouped per repository so one shared cache entry can
+    // serve any exclude_repos combination (the filter runs after the cache).
+    const repoGroups = await withDataCache(`v4:pt:${username.toLowerCase()}:${since}:${until}`, async () => {
         const userIdResponse = await userIdFetcher(token, {
             login: username
         });
@@ -109,24 +112,42 @@ export async function getProductiveTime(
 
         assertNoGraphQLErrors(res, 'GetProductiveTime failed');
 
-        const dates: Date[] = [];
+        const groups: Array<{name: string; nameWithOwner: string; dates: Date[]}> = [];
         res.data.data.user.contributionsCollection.commitContributionsByRepository.forEach(
             (node: {
                 repository: {
                     defaultBranchRef: {target: {history: {edges: any[]}}} | null;
+                    name: string;
+                    nameWithOwner: string;
                 };
             }) => {
                 if (node.repository.defaultBranchRef != null) {
+                    const dates: Date[] = [];
                     node.repository.defaultBranchRef.target.history.edges.forEach(edge => {
                         dates.push(edge.node.authoredDate);
+                    });
+                    groups.push({
+                        name: node.repository.name,
+                        nameWithOwner: node.repository.nameWithOwner,
+                        dates: dates
                     });
                 }
             }
         );
-        return dates;
+        return groups;
     });
 
     const productiveTime = new ProfuctiveTime();
-    authoredDates.forEach(date => productiveTime.addProductiveDate(date));
+    repoGroups.forEach(group => {
+        // Same matching rules as the language cards: case-insensitive on the
+        // bare repo name or the owner/repo form.
+        if (
+            excludeRepos.includes((group.name ?? '').toLowerCase()) ||
+            excludeRepos.includes((group.nameWithOwner ?? '').toLowerCase())
+        ) {
+            return;
+        }
+        group.dates.forEach(date => productiveTime.addProductiveDate(date));
+    });
     return productiveTime;
 }

--- a/tests/github-api/productive-time.test.ts
+++ b/tests/github-api/productive-time.test.ts
@@ -1,0 +1,93 @@
+import {getProductiveTime} from '../../src/github-api/productive-time';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+const mock = new MockAdapter(axios);
+
+const userIdData = {
+    data: {
+        user: {
+            id: 'USER_ID'
+        }
+    }
+};
+
+const repoGroup = function (name: string, owner: string, dates: Array<string>) {
+    return {
+        repository: {
+            defaultBranchRef: {
+                target: {
+                    history: {
+                        edges: dates.map(date => ({
+                            node: {message: 'commit', author: {email: 'mail@example.com'}, authoredDate: date}
+                        }))
+                    }
+                }
+            },
+            name: name,
+            nameWithOwner: `${owner}/${name}`
+        }
+    };
+};
+
+const productiveData = {
+    data: {
+        user: {
+            contributionsCollection: {
+                commitContributionsByRepository: [
+                    repoGroup('alpha', 'me', ['2026-01-01T10:00:00Z', '2026-01-02T11:00:00Z']),
+                    repoGroup('Beta', 'me', ['2026-01-03T12:00:00Z']),
+                    {repository: {defaultBranchRef: null, name: 'empty', nameWithOwner: 'me/empty'}}
+                ]
+            }
+        }
+    }
+};
+
+const error = {
+    errors: [
+        {
+            type: 'NOT_FOUND',
+            path: ['user'],
+            locations: [],
+            message: 'GitHub api failed'
+        }
+    ]
+};
+
+// distinct since/until per test so the shared data cache never collides
+const window = function (tag: string) {
+    return {since: `since-${tag}`, until: `until-${tag}`};
+};
+
+describe('getProductiveTime', () => {
+    beforeEach(() => {
+        mock.reset();
+    });
+
+    it('collects authored dates from every repository', async () => {
+        mock.onPost().replyOnce(200, userIdData).onPost().replyOnce(200, productiveData);
+        const {since, until} = window('all');
+        const productiveTime = await getProductiveTime('abda', until, since, 'token');
+        expect(productiveTime.productiveDate.length).toEqual(3);
+    });
+
+    it('skips repositories listed in excludeRepos, case-insensitively', async () => {
+        mock.onPost().replyOnce(200, userIdData).onPost().replyOnce(200, productiveData);
+        const {since, until} = window('name');
+        const productiveTime = await getProductiveTime('abda', until, since, 'token', ['beta']);
+        expect(productiveTime.productiveDate.length).toEqual(2);
+    });
+
+    it('matches owner/repo entries in excludeRepos', async () => {
+        mock.onPost().replyOnce(200, userIdData).onPost().replyOnce(200, productiveData);
+        const {since, until} = window('owner');
+        const productiveTime = await getProductiveTime('abda', until, since, 'token', ['me/alpha']);
+        expect(productiveTime.productiveDate.length).toEqual(1);
+    });
+
+    it('throws when the api responds with an error', async () => {
+        mock.onPost().replyOnce(200, error);
+        const {since, until} = window('error');
+        await expect(getProductiveTime('abda', until, since, 'token')).rejects.toThrow();
+    });
+});


### PR DESCRIPTION
### What

Adds the `exclude_repos` parameter (already supported by the repos-per-language and most-commit-language cards) to the **productive-time** card.

`.../api/cards/productive-time?username=me&utcOffset=4&exclude_repos=contribution-art,dotfiles`

### Why

I hit this as a user today: a decorative repo (contribution-graph pixel art, all commits scripted at the same hour) completely distorted my commits-per-hour chart with one giant bar. The language cards let me exclude it, productive-time did not.

Any bot-driven or scripted repo (mirrors, auto-backup, graph art) causes the same problem.

### How

- The ProductiveTime GraphQL query already groups history per repository, the repo name was just dropped during flattening. `getProductiveTime` now keeps the per-repo grouping through the data-cache boundary (cache key bumped `v3:pt` to `v4:pt` for the shape change) and filters **after** the cache, so one cached entry serves every `exclude_repos` combination.
- Matching rules are identical to the language cards: case-insensitive, bare repo name or `owner/repo` (query also fetches `nameWithOwner` now).
- Wired through the Vercel route (with an `exclude_repos_used` analytics flag mirroring repos-per-language) and the Action path (`EXCLUDE_REPOS` input now applies to this card too).
- README documents the new parameter.

### Tests

- New `tests/github-api/productive-time.test.ts`: unfiltered collection, bare-name exclusion, `owner/repo` exclusion, error path (4 tests).
- Full suite: 28 suites, 246 tests passing. `tsc --noEmit` and `eslint` clean.

Written with the help of Claude (reviewed and tested by me).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Productive-time cards can exclude selected repositories from activity calculations.
  * Repository exclusions support case-insensitive names and `owner/repository` formats.
  * The API accepts comma-separated repository exclusions and records whether exclusions were provided.

* **Documentation**
  * Added API documentation for the `exclude_repos` parameter.

* **Tests**
  * Added coverage for repository filtering, supported formats, date collection, and API errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->